### PR TITLE
Initial work for cloudtrail alarms module

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,23 @@
+version: 2
+jobs:
+  validate:
+    docker:
+      - image: trussworks/circleci-docker-primary:4013bb8c2428b3e2755d90a922abb2a6cea37ab4
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - pre-commit-dot-cache-{{ checksum ".pre-commit-config.yaml" }}
+      - run:
+          name: Run pre-commit tests
+          command: pre-commit run --all-files --show-diff-on-failure
+      - save_cache:
+          key: pre-commit-dot-cache-{{ checksum ".pre-commit-config.yaml" }}
+          paths:
+            - ~/.cache/pre-commit
+
+workflows:
+  version: 2
+  validate:
+    jobs:
+      - validate

--- a/.markdownlintrc
+++ b/.markdownlintrc
@@ -1,0 +1,8 @@
+{
+  "default": true,
+  "first-header-h1": false,
+  "first-line-h1": false,
+  "line_length": false,
+  "no-multiple-blanks": false,
+  "no-inline-html": false
+}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,28 @@
+repos:
+  - repo: git://github.com/pre-commit/pre-commit-hooks
+    rev: v2.5.0
+    hooks:
+      - id: check-json
+      - id: check-merge-conflict
+      - id: check-yaml
+      - id: detect-private-key
+      - id: pretty-format-json
+        args:
+          - --autofix
+      - id: trailing-whitespace
+
+  - repo: git://github.com/igorshubovych/markdownlint-cli
+    rev: v0.22.0
+    hooks:
+      - id: markdownlint
+
+  - repo: git://github.com/antonbabenko/pre-commit-terraform
+    rev: v1.27.0
+    hooks:
+      - id: terraform_docs
+      - id: terraform_fmt
+
+  - repo: git://github.com/golangci/golangci-lint
+    rev: v1.23.8
+    hooks:
+      - id: golangci-lint

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,8 +21,3 @@ repos:
     hooks:
       - id: terraform_docs
       - id: terraform_fmt
-
-  - repo: git://github.com/golangci/golangci-lint
-    rev: v1.23.8
-    hooks:
-      - id: golangci-lint

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# terraform-aws-cloudtrail-alarms
+
 This module creates a number of Cloudwatch alarms that alert on Cloudtrail
 events; they are meant to provide compliance with the AWS CIS benchmark.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 This module creates a number of Cloudwatch alarms that alert on Cloudtrail
 events; they are meant to provide compliance with the AWS CIS benchmark.
 
+This module uses Cloudtrail logs which have been written to a Cloudwatch
+logs group; this means for organizations with an organization Cloudtrail,
+you only need to put this in the master account.
+
 The following alarms are available in this module; all can be toggled on
 or off, but by default all alarms are active.
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,70 @@
-# terraform-aws-cloudtrail-alarms
-Provides CIS Benchmark-compliant Cloudwatch alarms for Cloudtrail events.
+This module creates a number of Cloudwatch alarms that alert on Cloudtrail
+events; they are meant to provide compliance with the AWS CIS benchmark.
+
+The following alarms are available in this module; all can be toggled on
+or off, but by default all alarms are active.
+
+* AWS Config changes
+* Cloudtrail config changes
+* Console signin failures
+* Disabling or deleting CMK
+* IAM changes
+* Network ACL changes
+* Network gateway changes
+* No MFA console logins
+* Root account usage
+* Route table changes
+* S3 bucket policy changes
+* Security group changes
+* Unauthorized API calls
+* VPC changes
+
+These alarms were adapted from those in
+<https://github.com/nozaq/terraform-aws-secure-baseline>.
+
+## Usage
+
+```hcl
+module "cloudtrail_alarms" {
+  source         = "trussworks/cloudtrail-alarms/aws"
+  version        = "~> 1.0.0"
+
+  alarm_sns_topic_arn = aws_sns_topic.my_alerts.arn
+}
+```
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Providers
+
+| Name | Version |
+|------|---------|
+| aws | n/a |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:-----:|
+| alarm\_namespace | Namespace for generated Cloudwatch alarms | `string` | `"CISBenchmark"` | no |
+| alarm\_sns\_topic\_arn | SNS topic ARN for generated alarms | `string` | n/a | yes |
+| aws\_config\_changes | Toggle AWS Config changes alarm | `bool` | `true` | no |
+| cloudtrail\_cfg\_changes | Toggle Cloudtrail config changes alarm | `bool` | `true` | no |
+| cloudtrail\_log\_group\_name | Cloudwatch log group name for Cloudtrail logs | `string` | `"cloudtrail-events"` | no |
+| console\_signin\_failures | Toggle console signin failures alarm | `bool` | `true` | no |
+| disable\_or\_delete\_cmk | Toggle disable or delete CMK alarm | `bool` | `true` | no |
+| iam\_changes | Toggle IAM changes alarm | `bool` | `true` | no |
+| nacl\_changes | Toggle network ACL changes alarm | `bool` | `true` | no |
+| network\_gw\_changes | Toggle network gateway changes alarm | `bool` | `true` | no |
+| no\_mfa\_console\_login | Toggle no MFA console login alarm | `bool` | `true` | no |
+| root\_usage | Toggle root usage alarm | `bool` | `true` | no |
+| route\_table\_changes | Toggle route table changes alarm | `bool` | `true` | no |
+| s3\_bucket\_policy\_changes | Toggle S3 bucket policy changes alarm | `bool` | `true` | no |
+| security\_group\_changes | Toggle security group changes alarm | `bool` | `true` | no |
+| unauthorized\_api\_calls | Toggle unauthorized api calls alarm | `bool` | `true` | no |
+| vpc\_changes | Toggle VPC changes alarm | `bool` | `true` | no |
+
+## Outputs
+
+No output.
+
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,489 @@
+resource "aws_cloudwatch_log_metric_filter" "unauthorized_api_calls" {
+  count = var.unauthorized_api_calls ? 1 : 0
+
+  name           = "UnauthorizedAPICalls"
+  pattern        = "{ ($.errorCode = \"*UnauthorizedOperation\") || ($.errorCode = \"AccessDenied*\") }"
+  log_group_name = var.cloudtrail_log_group_name
+
+  metric_transformation {
+    name      = "UnauthorizedAPICalls"
+    namespace = var.alarm_namespace
+    value     = "1"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "unauthorized_api_calls" {
+  count = var.unauthorized_api_calls ? 1 : 0
+
+  alarm_name                = "UnauthorizedAPICalls"
+  comparison_operator       = "GreaterThanOrEqualToThreshold"
+  evaluation_periods        = "1"
+  metric_name               = aws_cloudwatch_log_metric_filter.unauthorized_api_calls[0].id
+  namespace                 = var.alarm_namespace
+  period                    = "300"
+  statistic                 = "Sum"
+  threshold                 = "1"
+  alarm_description         = "Monitoring unauthorized API calls will help reveal application errors and may reduce time to detect malicious activity."
+  alarm_actions             = [var.alarm_sns_topic_arn]
+  treat_missing_data        = "notBreaching"
+  insufficient_data_actions = []
+
+  tags = {
+    Automation = "Terraform"
+  }
+}
+
+resource "aws_cloudwatch_log_metric_filter" "no_mfa_console_signin" {
+  count = var.no_mfa_console_login ? 1 : 0
+
+  name           = "NoMFAConsoleSignin"
+  pattern        = "{ ($.eventName = \"ConsoleLogin\") && ($.additionalEventData.MFAUsed != \"Yes\") }"
+  log_group_name = var.cloudtrail_log_group_name
+
+  metric_transformation {
+    name      = "NoMFAConsoleSignin"
+    namespace = var.alarm_namespace
+    value     = "1"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "no_mfa_console_signin" {
+  count = var.no_mfa_console_login ? 1 : 0
+
+  alarm_name                = "NoMFAConsoleSignin"
+  comparison_operator       = "GreaterThanOrEqualToThreshold"
+  evaluation_periods        = "1"
+  metric_name               = aws_cloudwatch_log_metric_filter.no_mfa_console_signin[0].id
+  namespace                 = var.alarm_namespace
+  period                    = "300"
+  statistic                 = "Sum"
+  threshold                 = "1"
+  alarm_description         = "Monitoring for single-factor console logins will increase visibility into accounts that are not protected by MFA."
+  alarm_actions             = [var.alarm_sns_topic_arn]
+  treat_missing_data        = "notBreaching"
+  insufficient_data_actions = []
+
+  tags = {
+    Automation = "Terraform"
+  }
+}
+
+resource "aws_cloudwatch_log_metric_filter" "root_usage" {
+  count = var.root_usage ? 1 : 0
+
+  name           = "RootUsage"
+  pattern        = "{ $.userIdentity.type = \"Root\" && $.userIdentity.invokedBy NOT EXISTS && $.eventType != \"AwsServiceEvent\" }"
+  log_group_name = var.cloudtrail_log_group_name
+
+  metric_transformation {
+    name      = "RootUsage"
+    namespace = var.alarm_namespace
+    value     = "1"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "root_usage" {
+  count = var.root_usage ? 1 : 0
+
+  alarm_name                = "RootUsage"
+  comparison_operator       = "GreaterThanOrEqualToThreshold"
+  evaluation_periods        = "1"
+  metric_name               = aws_cloudwatch_log_metric_filter.root_usage[0].id
+  namespace                 = var.alarm_namespace
+  period                    = "300"
+  statistic                 = "Sum"
+  threshold                 = "1"
+  alarm_description         = "Monitoring for root account logins will provide visibility into the use of a fully privileged account and an opportunity to reduce the use of it."
+  alarm_actions             = [var.alarm_sns_topic_arn]
+  treat_missing_data        = "notBreaching"
+  insufficient_data_actions = []
+
+  tags = {
+    Automation = "Terraform"
+  }
+}
+
+resource "aws_cloudwatch_log_metric_filter" "iam_changes" {
+  count = var.iam_changes ? 1 : 0
+
+  name           = "IAMChanges"
+  pattern        = "{($.eventName=DeleteGroupPolicy)||($.eventName=DeleteRolePolicy)||($.eventName=DeleteUserPolicy)||($.eventName=PutGroupPolicy)||($.eventName=PutRolePolicy)||($.eventName=PutUserPolicy)||($.eventName=CreatePolicy)||($.eventName=DeletePolicy)||($.eventName=CreatePolicyVersion)||($.eventName=DeletePolicyVersion)||($.eventName=AttachRolePolicy)||($.eventName=DetachRolePolicy)||($.eventName=AttachUserPolicy)||($.eventName=DetachUserPolicy)||($.eventName=AttachGroupPolicy)||($.eventName=DetachGroupPolicy)}"
+  log_group_name = var.cloudtrail_log_group_name
+
+  metric_transformation {
+    name      = "IAMChanges"
+    namespace = var.alarm_namespace
+    value     = "1"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "iam_changes" {
+  count = var.iam_changes ? 1 : 0
+
+  alarm_name                = "IAMChanges"
+  comparison_operator       = "GreaterThanOrEqualToThreshold"
+  evaluation_periods        = "1"
+  metric_name               = aws_cloudwatch_log_metric_filter.iam_changes[0].id
+  namespace                 = var.alarm_namespace
+  period                    = "300"
+  statistic                 = "Sum"
+  threshold                 = "1"
+  alarm_description         = "Monitoring changes to IAM policies will help ensure authentication and authorization controls remain intact."
+  alarm_actions             = [var.alarm_sns_topic_arn]
+  treat_missing_data        = "notBreaching"
+  insufficient_data_actions = []
+
+  tags = {
+    Automation = "Terraform"
+  }
+}
+
+resource "aws_cloudwatch_log_metric_filter" "cloudtrail_cfg_changes" {
+  count = var.cloudtrail_cfg_changes ? 1 : 0
+
+  name           = "CloudTrailCfgChanges"
+  pattern        = "{ ($.eventName = CreateTrail) || ($.eventName = UpdateTrail) || ($.eventName = DeleteTrail) || ($.eventName = StartLogging) || ($.eventName = StopLogging) }"
+  log_group_name = var.cloudtrail_log_group_name
+
+  metric_transformation {
+    name      = "CloudTrailCfgChanges"
+    namespace = var.alarm_namespace
+    value     = "1"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "cloudtrail_cfg_changes" {
+  count = var.cloudtrail_cfg_changes ? 1 : 0
+
+  alarm_name                = "CloudTrailCfgChanges"
+  comparison_operator       = "GreaterThanOrEqualToThreshold"
+  evaluation_periods        = "1"
+  metric_name               = aws_cloudwatch_log_metric_filter.cloudtrail_cfg_changes[0].id
+  namespace                 = var.alarm_namespace
+  period                    = "300"
+  statistic                 = "Sum"
+  threshold                 = "1"
+  alarm_description         = "Monitoring changes to CloudTrail's configuration will help ensure sustained visibility to activities performed in the AWS account."
+  alarm_actions             = [var.alarm_sns_topic_arn]
+  treat_missing_data        = "notBreaching"
+  insufficient_data_actions = []
+
+  tags = {
+    Automation = "Terraform"
+  }
+}
+
+resource "aws_cloudwatch_log_metric_filter" "console_signin_failures" {
+  count = var.console_signin_failures ? 1 : 0
+
+  name           = "ConsoleSigninFailures"
+  pattern        = "{ ($.eventName = ConsoleLogin) && ($.errorMessage = \"Failed authentication\") }"
+  log_group_name = var.cloudtrail_log_group_name
+
+  metric_transformation {
+    name      = "ConsoleSigninFailures"
+    namespace = var.alarm_namespace
+    value     = "1"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "console_signin_failures" {
+  count = var.console_signin_failures ? 1 : 0
+
+  alarm_name                = "ConsoleSigninFailures"
+  comparison_operator       = "GreaterThanOrEqualToThreshold"
+  evaluation_periods        = "1"
+  metric_name               = aws_cloudwatch_log_metric_filter.console_signin_failures[0].id
+  namespace                 = var.alarm_namespace
+  period                    = "300"
+  statistic                 = "Sum"
+  threshold                 = "1"
+  alarm_description         = "Monitoring failed console logins may decrease lead time to detect an attempt to brute force a credential, which may provide an indicator, such as source IP, that can be used in other event correlation."
+  alarm_actions             = [var.alarm_sns_topic_arn]
+  treat_missing_data        = "notBreaching"
+  insufficient_data_actions = []
+
+  tags = {
+    Automation = "Terraform"
+  }
+}
+
+resource "aws_cloudwatch_log_metric_filter" "disable_or_delete_cmk" {
+  count = var.disable_or_delete_cmk ? 1 : 0
+
+  name           = "DisableOrDeleteCMK"
+  pattern        = "{ ($.eventSource = kms.amazonaws.com) && (($.eventName = DisableKey) || ($.eventName = ScheduleKeyDeletion)) }"
+  log_group_name = var.cloudtrail_log_group_name
+
+  metric_transformation {
+    name      = "DisableOrDeleteCMK"
+    namespace = var.alarm_namespace
+    value     = "1"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "disable_or_delete_cmk" {
+  count = var.disable_or_delete_cmk ? 1 : 0
+
+  alarm_name                = "DisableOrDeleteCMK"
+  comparison_operator       = "GreaterThanOrEqualToThreshold"
+  evaluation_periods        = "1"
+  metric_name               = aws_cloudwatch_log_metric_filter.disable_or_delete_cmk[0].id
+  namespace                 = var.alarm_namespace
+  period                    = "300"
+  statistic                 = "Sum"
+  threshold                 = "1"
+  alarm_description         = "Monitoring failed console logins may decrease lead time to detect an attempt to brute force a credential, which may provide an indicator, such as source IP, that can be used in other event correlation."
+  alarm_actions             = [var.alarm_sns_topic_arn]
+  treat_missing_data        = "notBreaching"
+  insufficient_data_actions = []
+
+  tags = {
+    Automation = "Terraform"
+  }
+}
+
+resource "aws_cloudwatch_log_metric_filter" "s3_bucket_policy_changes" {
+  count = var.s3_bucket_policy_changes ? 1 : 0
+
+  name           = "S3BucketPolicyChanges"
+  pattern        = "{ ($.eventSource = s3.amazonaws.com) && (($.eventName = PutBucketAcl) || ($.eventName = PutBucketPolicy) || ($.eventName = PutBucketCors) || ($.eventName = PutBucketLifecycle) || ($.eventName = PutBucketReplication) || ($.eventName = DeleteBucketPolicy) || ($.eventName = DeleteBucketCors) || ($.eventName = DeleteBucketLifecycle) || ($.eventName = DeleteBucketReplication)) }"
+  log_group_name = var.cloudtrail_log_group_name
+
+  metric_transformation {
+    name      = "S3BucketPolicyChanges"
+    namespace = var.alarm_namespace
+    value     = "1"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "s3_bucket_policy_changes" {
+  count = var.s3_bucket_policy_changes ? 1 : 0
+
+  alarm_name                = "S3BucketPolicyChanges"
+  comparison_operator       = "GreaterThanOrEqualToThreshold"
+  evaluation_periods        = "1"
+  metric_name               = aws_cloudwatch_log_metric_filter.s3_bucket_policy_changes[0].id
+  namespace                 = var.alarm_namespace
+  period                    = "300"
+  statistic                 = "Sum"
+  threshold                 = "1"
+  alarm_description         = "Monitoring changes to S3 bucket policies may reduce time to detect and correct permissive policies on sensitive S3 buckets."
+  alarm_actions             = [var.alarm_sns_topic_arn]
+  treat_missing_data        = "notBreaching"
+  insufficient_data_actions = []
+
+  tags = {
+    Automation = "Terraform"
+  }
+}
+
+resource "aws_cloudwatch_log_metric_filter" "aws_config_changes" {
+  count = var.aws_config_changes ? 1 : 0
+
+  name           = "AWSConfigChanges"
+  pattern        = "{ ($.eventSource = config.amazonaws.com) && (($.eventName=StopConfigurationRecorder)||($.eventName=DeleteDeliveryChannel)||($.eventName=PutDeliveryChannel)||($.eventName=PutConfigurationRecorder)) }"
+  log_group_name = var.cloudtrail_log_group_name
+
+  metric_transformation {
+    name      = "AWSConfigChanges"
+    namespace = var.alarm_namespace
+    value     = "1"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "aws_config_changes" {
+  count = var.aws_config_changes ? 1 : 0
+
+  alarm_name                = "AWSConfigChanges"
+  comparison_operator       = "GreaterThanOrEqualToThreshold"
+  evaluation_periods        = "1"
+  metric_name               = aws_cloudwatch_log_metric_filter.aws_config_changes[0].id
+  namespace                 = var.alarm_namespace
+  period                    = "300"
+  statistic                 = "Sum"
+  threshold                 = "1"
+  alarm_description         = "Monitoring changes to AWS Config configuration will help ensure sustained visibility of configuration items within the AWS account."
+  alarm_actions             = [var.alarm_sns_topic_arn]
+  treat_missing_data        = "notBreaching"
+  insufficient_data_actions = []
+
+  tags = {
+    Automation = "Terraform"
+  }
+}
+
+resource "aws_cloudwatch_log_metric_filter" "security_group_changes" {
+  count = var.security_group_changes ? 1 : 0
+
+  name           = "SecurityGroupChanges"
+  pattern        = "{ ($.eventName = AuthorizeSecurityGroupIngress) || ($.eventName = AuthorizeSecurityGroupEgress) || ($.eventName = RevokeSecurityGroupIngress) || ($.eventName = RevokeSecurityGroupEgress) || ($.eventName = CreateSecurityGroup) || ($.eventName = DeleteSecurityGroup)}"
+  log_group_name = var.cloudtrail_log_group_name
+
+  metric_transformation {
+    name      = "SecurityGroupChanges"
+    namespace = var.alarm_namespace
+    value     = "1"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "security_group_changes" {
+  count = var.security_group_changes ? 1 : 0
+
+  alarm_name                = "SecurityGroupChanges"
+  comparison_operator       = "GreaterThanOrEqualToThreshold"
+  evaluation_periods        = "1"
+  metric_name               = aws_cloudwatch_log_metric_filter.security_group_changes[0].id
+  namespace                 = var.alarm_namespace
+  period                    = "300"
+  statistic                 = "Sum"
+  threshold                 = "1"
+  alarm_description         = "Monitoring changes to security group will help ensure that resources and services are not unintentionally exposed."
+  alarm_actions             = [var.alarm_sns_topic_arn]
+  treat_missing_data        = "notBreaching"
+  insufficient_data_actions = []
+
+  tags = {
+    Automation = "Terraform"
+  }
+}
+
+resource "aws_cloudwatch_log_metric_filter" "nacl_changes" {
+  count = var.nacl_changes ? 1 : 0
+
+  name           = "NACLChanges"
+  pattern        = "{ ($.eventName = CreateNetworkAcl) || ($.eventName = CreateNetworkAclEntry) || ($.eventName = DeleteNetworkAcl) || ($.eventName = DeleteNetworkAclEntry) || ($.eventName = ReplaceNetworkAclEntry) || ($.eventName = ReplaceNetworkAclAssociation) }"
+  log_group_name = var.cloudtrail_log_group_name
+
+  metric_transformation {
+    name      = "NACLChanges"
+    namespace = var.alarm_namespace
+    value     = "1"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "nacl_changes" {
+  count = var.nacl_changes ? 1 : 0
+
+  alarm_name                = "NACLChanges"
+  comparison_operator       = "GreaterThanOrEqualToThreshold"
+  evaluation_periods        = "1"
+  metric_name               = aws_cloudwatch_log_metric_filter.nacl_changes[0].id
+  namespace                 = var.alarm_namespace
+  period                    = "300"
+  statistic                 = "Sum"
+  threshold                 = "1"
+  alarm_description         = "Monitoring changes to NACLs will help ensure that AWS resources and services are not unintentionally exposed."
+  alarm_actions             = [var.alarm_sns_topic_arn]
+  treat_missing_data        = "notBreaching"
+  insufficient_data_actions = []
+
+  tags = {
+    Automation = "Terraform"
+  }
+}
+
+resource "aws_cloudwatch_log_metric_filter" "network_gw_changes" {
+  count = var.network_gw_changes ? 1 : 0
+
+  name           = "NetworkGWChanges"
+  pattern        = "{ ($.eventName = CreateCustomerGateway) || ($.eventName = DeleteCustomerGateway) || ($.eventName = AttachInternetGateway) || ($.eventName = CreateInternetGateway) || ($.eventName = DeleteInternetGateway) || ($.eventName = DetachInternetGateway) }"
+  log_group_name = var.cloudtrail_log_group_name
+
+  metric_transformation {
+    name      = "NetworkGWChanges"
+    namespace = var.alarm_namespace
+    value     = "1"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "network_gw_changes" {
+  count = var.network_gw_changes ? 1 : 0
+
+  alarm_name                = "NetworkGWChanges"
+  comparison_operator       = "GreaterThanOrEqualToThreshold"
+  evaluation_periods        = "1"
+  metric_name               = aws_cloudwatch_log_metric_filter.network_gw_changes[0].id
+  namespace                 = var.alarm_namespace
+  period                    = "300"
+  statistic                 = "Sum"
+  threshold                 = "1"
+  alarm_description         = "Monitoring changes to network gateways will help ensure that all ingress/egress traffic traverses the VPC border via a controlled path."
+  alarm_actions             = [var.alarm_sns_topic_arn]
+  treat_missing_data        = "notBreaching"
+  insufficient_data_actions = []
+
+  tags = {
+    Automation = "Terraform"
+  }
+}
+
+resource "aws_cloudwatch_log_metric_filter" "route_table_changes" {
+  count = var.route_table_changes ? 1 : 0
+
+  name           = "RouteTableChanges"
+  pattern        = "{ ($.eventName = CreateRoute) || ($.eventName = CreateRouteTable) || ($.eventName = ReplaceRoute) || ($.eventName = ReplaceRouteTableAssociation) || ($.eventName = DeleteRouteTable) || ($.eventName = DeleteRoute) || ($.eventName = DisassociateRouteTable) }"
+  log_group_name = var.cloudtrail_log_group_name
+
+  metric_transformation {
+    name      = "RouteTableChanges"
+    namespace = var.alarm_namespace
+    value     = "1"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "route_table_changes" {
+  count = var.route_table_changes ? 1 : 0
+
+  alarm_name                = "RouteTableChanges"
+  comparison_operator       = "GreaterThanOrEqualToThreshold"
+  evaluation_periods        = "1"
+  metric_name               = aws_cloudwatch_log_metric_filter.route_table_changes[0].id
+  namespace                 = var.alarm_namespace
+  period                    = "300"
+  statistic                 = "Sum"
+  threshold                 = "1"
+  alarm_description         = "Monitoring changes to route tables will help ensure that all VPC traffic flows through an expected path."
+  alarm_actions             = [var.alarm_sns_topic_arn]
+  treat_missing_data        = "notBreaching"
+  insufficient_data_actions = []
+
+  tags = {
+    Automation = "Terraform"
+  }
+}
+
+resource "aws_cloudwatch_log_metric_filter" "vpc_changes" {
+  count = var.vpc_changes ? 1 : 0
+
+  name           = "VPCChanges"
+  pattern        = "{ ($.eventName = CreateVpc) || ($.eventName = DeleteVpc) || ($.eventName = ModifyVpcAttribute) || ($.eventName = AcceptVpcPeeringConnection) || ($.eventName = CreateVpcPeeringConnection) || ($.eventName = DeleteVpcPeeringConnection) || ($.eventName = RejectVpcPeeringConnection) || ($.eventName = AttachClassicLinkVpc) || ($.eventName = DetachClassicLinkVpc) || ($.eventName = DisableVpcClassicLink) || ($.eventName = EnableVpcClassicLink) }"
+  log_group_name = var.cloudtrail_log_group_name
+
+  metric_transformation {
+    name      = "VPCChanges"
+    namespace = var.alarm_namespace
+    value     = "1"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "vpc_changes" {
+  count = var.vpc_changes ? 1 : 0
+
+  alarm_name                = "VPCChanges"
+  comparison_operator       = "GreaterThanOrEqualToThreshold"
+  evaluation_periods        = "1"
+  metric_name               = aws_cloudwatch_log_metric_filter.vpc_changes[0].id
+  namespace                 = var.alarm_namespace
+  period                    = "300"
+  statistic                 = "Sum"
+  threshold                 = "1"
+  alarm_description         = "Monitoring changes to VPC will help ensure that all VPC traffic flows through an expected path."
+  alarm_actions             = [var.alarm_sns_topic_arn]
+  treat_missing_data        = "notBreaching"
+  insufficient_data_actions = []
+
+  tags = {
+    Automation = "Terraform"
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,104 @@
+# Setup Variables
+
+variable "alarm_namespace" {
+  description = "Namespace for generated Cloudwatch alarms"
+  type        = string
+  default     = "CISBenchmark"
+}
+
+variable "alarm_sns_topic_arn" {
+  description = "SNS topic ARN for generated alarms"
+  type        = string
+}
+
+variable "cloudtrail_log_group_name" {
+  description = "Cloudwatch log group name for Cloudtrail logs"
+  type        = string
+  default     = "cloudtrail-events"
+}
+
+# Alarm Toggles
+
+variable "aws_config_changes" {
+  description = "Toggle AWS Config changes alarm"
+  type        = bool
+  default     = true
+}
+
+variable "cloudtrail_cfg_changes" {
+  description = "Toggle Cloudtrail config changes alarm"
+  type        = bool
+  default     = true
+}
+
+variable "console_signin_failures" {
+  description = "Toggle console signin failures alarm"
+  type        = bool
+  default     = true
+}
+
+variable "disable_or_delete_cmk" {
+  description = "Toggle disable or delete CMK alarm"
+  type        = bool
+  default     = true
+}
+
+variable "iam_changes" {
+  description = "Toggle IAM changes alarm"
+  type        = bool
+  default     = true
+}
+
+variable "nacl_changes" {
+  description = "Toggle network ACL changes alarm"
+  type        = bool
+  default     = true
+}
+
+variable "network_gw_changes" {
+  description = "Toggle network gateway changes alarm"
+  type        = bool
+  default     = true
+}
+
+variable "no_mfa_console_login" {
+  description = "Toggle no MFA console login alarm"
+  type        = bool
+  default     = true
+}
+
+variable "root_usage" {
+  description = "Toggle root usage alarm"
+  type        = bool
+  default     = true
+}
+
+variable "route_table_changes" {
+  description = "Toggle route table changes alarm"
+  type        = bool
+  default     = true
+}
+
+variable "s3_bucket_policy_changes" {
+  description = "Toggle S3 bucket policy changes alarm"
+  type        = bool
+  default     = true
+}
+
+variable "security_group_changes" {
+  description = "Toggle security group changes alarm"
+  type        = bool
+  default     = true
+}
+
+variable "unauthorized_api_calls" {
+  description = "Toggle unauthorized api calls alarm"
+  type        = bool
+  default     = true
+}
+
+variable "vpc_changes" {
+  description = "Toggle VPC changes alarm"
+  type        = bool
+  default     = true
+}

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
This module will create a set of cloudtrail alarms based on the ones in this module: 

https://github.com/nozaq/terraform-aws-secure-baseline/tree/master/modules/alarm-baseline

I'm just using most of that code with some slight tweaks to make it work standalone. It needs to be installed in the account where you have Cloudtrail logs going into Cloudwatch; so in an organization with organization-level cloudtrail, that's just the org-root account.

I've done a TF plan with this module in our environment and it looks good.