### PR TITLE
Adding option to disable assumed-role console login alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ module "cloudtrail_alarms" {
 | cloudtrail\_cfg\_changes | Toggle Cloudtrail config changes alarm | `bool` | `true` | no |
 | cloudtrail\_log\_group\_name | Cloudwatch log group name for Cloudtrail logs | `string` | `"cloudtrail-events"` | no |
 | console\_signin\_failures | Toggle console signin failures alarm | `bool` | `true` | no |
+| disable\_assumed\_role\_login\_alerts | Toggle to disable assumed role console login alerts - violates CIS Benchmark | `bool` | `false` | no |
 | disable\_or\_delete\_cmk | Toggle disable or delete CMK alarm | `bool` | `true` | no |
 | iam\_changes | Toggle IAM changes alarm | `bool` | `true` | no |
 | nacl\_changes | Toggle network ACL changes alarm | `bool` | `true` | no |

--- a/variables.tf
+++ b/variables.tf
@@ -17,6 +17,14 @@ variable "cloudtrail_log_group_name" {
   default     = "cloudtrail-events"
 }
 
+# Behavior Toggles
+
+variable "disable_assumed_role_login_alerts" {
+  description = "Toggle to disable assumed role console login alerts - violates CIS Benchmark"
+  type        = bool
+  default     = false
+}
+
 # Alarm Toggles
 
 variable "aws_config_changes" {


### PR DESCRIPTION
So, it turns out that when you log in to the console via an assumed role, that counts as a "NoMFAConsoleLogin" because the *role* didn't use an MFA, *you* used the MFA to assume the role. 🙃 This means that especially in our sandbox environment this becomes *very* spammy as people log in.

In order to fix this, I've added an extra toggle to disable alerts for logins by assumed roles. I don't think this is strictly within the rule of the CIS benchmark for AWS (I had a chat with Barry about this yesterday, and I'm not entire sure that's true, but...), but without that, this alert is almost useless for us -- and I *do* want to have this as an alert, because if someone logs in without an MFA that's a giant red flag, especially on the org-root account (and since this is an org-wide Cloudtrail, I don't want to turn this off for all our Cloudtrail events).

I've made note that this violates the CIS benchmark in the variable description, which hopefully is a good middle ground.

Here's an example from our environment where I've toggled this option on:

```text
An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  + create
  ~ update in-place
  - destroy

Terraform will perform the following actions:

  # module.cloudtrail_alarms.aws_cloudwatch_log_metric_filter.no_mfa_console_signin[0] will be destroyed
  - resource "aws_cloudwatch_log_metric_filter" "no_mfa_console_signin" {
      - id             = "NoMFAConsoleSignin" -> null
      - log_group_name = "cloudtrail-events" -> null
      - name           = "NoMFAConsoleSignin" -> null
      - pattern        = "{ ($.eventName = \"ConsoleLogin\") && ($.additionalEventData.MFAUsed != \"Yes\") }" -> null

      - metric_transformation {
          - name      = "NoMFAConsoleSignin" -> null
          - namespace = "CISBenchmark" -> null
          - value     = "1" -> null
        }
    }

  # module.cloudtrail_alarms.aws_cloudwatch_log_metric_filter.no_mfa_console_signin_no_assumed_role[0] will be created
  + resource "aws_cloudwatch_log_metric_filter" "no_mfa_console_signin_no_assumed_role" {
      + id             = (known after apply)
      + log_group_name = "cloudtrail-events"
      + name           = "NoMFAConsoleSignin"
      + pattern        = "{ ($.eventName = \"ConsoleLogin\") && ($.additionalEventData.MFAUsed != \"Yes\") && ($.userIdentity.arn != \"*assumed-role*\") }"

      + metric_transformation {
          + name      = "NoMFAConsoleSignin"
          + namespace = "CISBenchmark"
          + value     = "1"
        }
    }

  # module.cloudtrail_alarms.aws_cloudwatch_metric_alarm.no_mfa_console_signin[0] will be updated in-place
  ~ resource "aws_cloudwatch_metric_alarm" "no_mfa_console_signin" {
        actions_enabled           = true
        alarm_actions             = [
            "arn:aws:sns:us-west-2:xxxxxxxx8026:saber-slack-alerts",
        ]
        alarm_description         = "Monitoring for single-factor console logins will increase visibility into accounts that are not protected by MFA."
        alarm_name                = "NoMFAConsoleSignin"
        arn                       = "arn:aws:cloudwatch:us-west-2:xxxxxxxx8026:alarm:NoMFAConsoleSignin"
        comparison_operator       = "GreaterThanOrEqualToThreshold"
        datapoints_to_alarm       = 0
        dimensions                = {}
        evaluation_periods        = 1
        id                        = "NoMFAConsoleSignin"
        insufficient_data_actions = []
      ~ metric_name               = "NoMFAConsoleSignin" -> (known after apply)
        namespace                 = "CISBenchmark"
        ok_actions                = []
        period                    = 300
        statistic                 = "Sum"
        tags                      = {
            "Automation" = "Terraform"
        }
        threshold                 = 1
        treat_missing_data        = "notBreaching"
    }

Plan: 1 to add, 1 to change, 1 to destroy.
```

And without the toggle on:
```text
An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  + create
  ~ update in-place
  - destroy

Terraform will perform the following actions:

  # module.cloudtrail_alarms.aws_cloudwatch_log_metric_filter.no_mfa_console_signin[0] will be destroyed
  - resource "aws_cloudwatch_log_metric_filter" "no_mfa_console_signin" {
      - id             = "NoMFAConsoleSignin" -> null
      - log_group_name = "cloudtrail-events" -> null
      - name           = "NoMFAConsoleSignin" -> null
      - pattern        = "{ ($.eventName = \"ConsoleLogin\") && ($.additionalEventData.MFAUsed != \"Yes\") }" -> null

      - metric_transformation {
          - name      = "NoMFAConsoleSignin" -> null
          - namespace = "CISBenchmark" -> null
          - value     = "1" -> null
        }
    }

  # module.cloudtrail_alarms.aws_cloudwatch_log_metric_filter.no_mfa_console_signin_assumed_role[0] will be created
  + resource "aws_cloudwatch_log_metric_filter" "no_mfa_console_signin_assumed_role" {
      + id             = (known after apply)
      + log_group_name = "cloudtrail-events"
      + name           = "NoMFAConsoleSignin"
      + pattern        = "{ ($.eventName = \"ConsoleLogin\") && ($.additionalEventData.MFAUsed != \"Yes\") }"

      + metric_transformation {
          + name      = "NoMFAConsoleSignin"
          + namespace = "CISBenchmark"
          + value     = "1"
        }
    }

  # module.cloudtrail_alarms.aws_cloudwatch_metric_alarm.no_mfa_console_signin[0] will be updated in-place
  ~ resource "aws_cloudwatch_metric_alarm" "no_mfa_console_signin" {
        actions_enabled           = true
        alarm_actions             = [
            "arn:aws:sns:us-west-2:xxxxxxxx8026:saber-slack-alerts",
        ]
        alarm_description         = "Monitoring for single-factor console logins will increase visibility into accounts that are not protected by MFA."
        alarm_name                = "NoMFAConsoleSignin"
        arn                       = "arn:aws:cloudwatch:us-west-2:xxxxxxxx8026:alarm:NoMFAConsoleSignin"
        comparison_operator       = "GreaterThanOrEqualToThreshold"
        datapoints_to_alarm       = 0
        dimensions                = {}
        evaluation_periods        = 1
        id                        = "NoMFAConsoleSignin"
        insufficient_data_actions = []
      ~ metric_name               = "NoMFAConsoleSignin" -> (known after apply)
        namespace                 = "CISBenchmark"
        ok_actions                = []
        period                    = 300
        statistic                 = "Sum"
        tags                      = {
            "Automation" = "Terraform"
        }
        threshold                 = 1
        treat_missing_data        = "notBreaching"
    }

Plan: 1 to add, 1 to change, 1 to destroy.
```