### PR TITLE
Rek 172185702 add accounts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   validate:
     docker:
-      - image: trussworks/circleci-docker-primary:4013bb8c2428b3e2755d90a922abb2a6cea37ab4
+      - image: trussworks/circleci-docker-primary:2f6321ed86ed79bfed23b04dd6dfdbe7bc943fdc
     steps:
       - checkout
       - restore_cache:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
       - id: markdownlint
 
   - repo: git://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.27.0
+    rev: v1.29.0
     hooks:
       - id: terraform_docs
       - id: terraform_fmt

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ module "cloudtrail_alarms" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| accounts | To split alert by account, add account IDs of interest | <pre>list(<br>    object({<br>      account_id   = string<br>      account_name = string<br>      }<br>    )<br>  )</pre> | n/a | yes |
+| accounts | List of account objects containing the account\_id and account\_name to alert on. | <pre>list(<br>    object({<br>      account_id   = string<br>      account_name = string<br>      }<br>    )<br>  )</pre> | n/a | yes |
 | alarm\_namespace | Namespace for generated Cloudwatch alarms | `string` | `"CISBenchmark"` | no |
 | alarm\_sns\_topic\_arn | SNS topic ARN for generated alarms | `string` | n/a | yes |
 | aws\_config\_changes | Toggle AWS Config changes alarm | `bool` | `true` | no |

--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ module "cloudtrail_alarms" {
 ```
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| terraform | >= 0.12 |
+
 ## Providers
 
 | Name | Version |
@@ -49,7 +55,8 @@ module "cloudtrail_alarms" {
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:-----:|
+|------|-------------|------|---------|:--------:|
+| accounts | To split alert by account, add account IDs of interest | <pre>list(<br>    object({<br>      account_id   = string<br>      account_name = string<br>      }<br>    )<br>  )</pre> | n/a | yes |
 | alarm\_namespace | Namespace for generated Cloudwatch alarms | `string` | `"CISBenchmark"` | no |
 | alarm\_sns\_topic\_arn | SNS topic ARN for generated alarms | `string` | n/a | yes |
 | aws\_config\_changes | Toggle AWS Config changes alarm | `bool` | `true` | no |

--- a/main.tf
+++ b/main.tf
@@ -8,7 +8,7 @@ locals {
 resource "aws_cloudwatch_log_metric_filter" "unauthorized_api_calls" {
   count = var.unauthorized_api_calls ? length(var.accounts) : 0
 
-  name           = "UnauthorizedAPICalls ${element(var.accounts, count.index).account_name}"
+  name           = "UnauthorizedAPICalls-${element(var.accounts, count.index).account_name}"
   pattern        = "{ (($.errorCode = \"*UnauthorizedOperation\") || ($.errorCode = \"AccessDenied*\")) && ($.userIdentity.accountId = ${element(var.accounts, count.index).account_id}) }"
   log_group_name = var.cloudtrail_log_group_name
 
@@ -93,7 +93,7 @@ resource "aws_cloudwatch_metric_alarm" "no_mfa_console_signin" {
 resource "aws_cloudwatch_log_metric_filter" "root_usage" {
   count = var.root_usage ? length(var.accounts) : 0
 
-  name           = "RootUsage ${element(var.accounts, count.index).account_name}"
+  name           = "RootUsage-${element(var.accounts, count.index).account_name}"
   pattern        = "{ $.userIdentity.type = \"Root\" && $.userIdentity.invokedBy NOT EXISTS && $.eventType != \"AwsServiceEvent\" && $.userIdentity.accountId = ${element(var.accounts, count.index).account_id} }"
   log_group_name = var.cloudtrail_log_group_name
 
@@ -128,7 +128,7 @@ resource "aws_cloudwatch_metric_alarm" "root_usage" {
 resource "aws_cloudwatch_log_metric_filter" "iam_changes" {
   count = var.iam_changes ? length(var.accounts) : 0
 
-  name           = "IAMChanges ${element(var.accounts, count.index).account_name}"
+  name           = "IAMChanges-${element(var.accounts, count.index).account_name}"
   pattern        = "{ ${local.iam_changes_pattern} && ($.userIdentity.accountId = ${element(var.accounts, count.index).account_id}) }"
   log_group_name = var.cloudtrail_log_group_name
 
@@ -163,7 +163,7 @@ resource "aws_cloudwatch_metric_alarm" "iam_changes" {
 resource "aws_cloudwatch_log_metric_filter" "cloudtrail_cfg_changes" {
   count = var.cloudtrail_cfg_changes ? length(var.accounts) : 0
 
-  name           = "CloudTrailCfgChanges ${element(var.accounts, count.index).account_name}"
+  name           = "CloudTrailCfgChanges-${element(var.accounts, count.index).account_name}"
   pattern        = "{ (($.eventName = CreateTrail) || ($.eventName = UpdateTrail) || ($.eventName = DeleteTrail) || ($.eventName = StartLogging) || ($.eventName = StopLogging)) && ($.userIdentity.accountId = ${element(var.accounts, count.index).account_id}) }"
   log_group_name = var.cloudtrail_log_group_name
 
@@ -198,7 +198,7 @@ resource "aws_cloudwatch_metric_alarm" "cloudtrail_cfg_changes" {
 resource "aws_cloudwatch_log_metric_filter" "console_signin_failures" {
   count = var.console_signin_failures ? length(var.accounts) : 0
 
-  name           = "ConsoleSigninFailures ${element(var.accounts, count.index).account_name}"
+  name           = "ConsoleSigninFailures-${element(var.accounts, count.index).account_name}"
   pattern        = "{ ($.eventName = ConsoleLogin) && ($.errorMessage = \"Failed authentication\") && ($.userIdentity.accountId = ${element(var.accounts, count.index).account_id}) }"
   log_group_name = var.cloudtrail_log_group_name
 
@@ -233,7 +233,7 @@ resource "aws_cloudwatch_metric_alarm" "console_signin_failures" {
 resource "aws_cloudwatch_log_metric_filter" "disable_or_delete_cmk" {
   count = var.disable_or_delete_cmk ? length(var.accounts) : 0
 
-  name           = "DisableOrDeleteCMK ${element(var.accounts, count.index).account_name}"
+  name           = "DisableOrDeleteCMK-${element(var.accounts, count.index).account_name}"
   pattern        = "{ ($.eventSource = kms.amazonaws.com) && (($.eventName = DisableKey) || ($.eventName = ScheduleKeyDeletion)) && ($.userIdentity.accountId = ${element(var.accounts, count.index).account_id}) }"
   log_group_name = var.cloudtrail_log_group_name
 
@@ -268,7 +268,7 @@ resource "aws_cloudwatch_metric_alarm" "disable_or_delete_cmk" {
 resource "aws_cloudwatch_log_metric_filter" "s3_bucket_policy_changes" {
   count = var.s3_bucket_policy_changes ? length(var.accounts) : 0
 
-  name           = "S3BucketPolicyChanges ${element(var.accounts, count.index).account_name}"
+  name           = "S3BucketPolicyChanges-${element(var.accounts, count.index).account_name}"
   pattern        = "{ ($.eventSource = s3.amazonaws.com) && (($.eventName = PutBucketAcl) || ($.eventName = PutBucketPolicy) || ($.eventName = PutBucketCors) || ($.eventName = PutBucketLifecycle) || ($.eventName = PutBucketReplication) || ($.eventName = DeleteBucketPolicy) || ($.eventName = DeleteBucketCors) || ($.eventName = DeleteBucketLifecycle) || ($.eventName = DeleteBucketReplication)) && ($.userIdentity.accountId = ${element(var.accounts, count.index).account_id}) }"
   log_group_name = var.cloudtrail_log_group_name
 
@@ -303,7 +303,7 @@ resource "aws_cloudwatch_metric_alarm" "s3_bucket_policy_changes" {
 resource "aws_cloudwatch_log_metric_filter" "aws_config_changes" {
   count = var.aws_config_changes ? length(var.accounts) : 0
 
-  name           = "AWSConfigChanges ${element(var.accounts, count.index).account_name}"
+  name           = "AWSConfigChanges-${element(var.accounts, count.index).account_name}"
   pattern        = "{ ($.eventSource = config.amazonaws.com) && (($.eventName=StopConfigurationRecorder)||($.eventName=DeleteDeliveryChannel)||($.eventName=PutDeliveryChannel)||($.eventName=PutConfigurationRecorder)) && ($.userIdentity.accountId = ${element(var.accounts, count.index).account_id}) }"
   log_group_name = var.cloudtrail_log_group_name
 
@@ -338,7 +338,7 @@ resource "aws_cloudwatch_metric_alarm" "aws_config_changes" {
 resource "aws_cloudwatch_log_metric_filter" "security_group_changes" {
   count = var.security_group_changes ? length(var.accounts) : 0
 
-  name           = "SecurityGroupChanges ${element(var.accounts, count.index).account_name}"
+  name           = "SecurityGroupChanges-${element(var.accounts, count.index).account_name}"
   pattern        = "{ (($.eventName = AuthorizeSecurityGroupIngress) || ($.eventName = AuthorizeSecurityGroupEgress) || ($.eventName = RevokeSecurityGroupIngress) || ($.eventName = RevokeSecurityGroupEgress) || ($.eventName = CreateSecurityGroup) || ($.eventName = DeleteSecurityGroup)) && ($.userIdentity.accountId = ${element(var.accounts, count.index).account_id})}"
   log_group_name = var.cloudtrail_log_group_name
 
@@ -373,7 +373,7 @@ resource "aws_cloudwatch_metric_alarm" "security_group_changes" {
 resource "aws_cloudwatch_log_metric_filter" "nacl_changes" {
   count = var.nacl_changes ? length(var.accounts) : 0
 
-  name           = "NACLChanges ${element(var.accounts, count.index).account_name}"
+  name           = "NACLChanges-${element(var.accounts, count.index).account_name}"
   pattern        = "{ (($.eventName = CreateNetworkAcl) || ($.eventName = CreateNetworkAclEntry) || ($.eventName = DeleteNetworkAcl) || ($.eventName = DeleteNetworkAclEntry) || ($.eventName = ReplaceNetworkAclEntry) || ($.eventName = ReplaceNetworkAclAssociation)) && ($.userIdentity.accountId = ${element(var.accounts, count.index).account_id}) }"
   log_group_name = var.cloudtrail_log_group_name
 
@@ -408,7 +408,7 @@ resource "aws_cloudwatch_metric_alarm" "nacl_changes" {
 resource "aws_cloudwatch_log_metric_filter" "network_gw_changes" {
   count = var.network_gw_changes ? length(var.accounts) : 0
 
-  name           = "NetworkGWChanges ${element(var.accounts, count.index).account_name}"
+  name           = "NetworkGWChanges-${element(var.accounts, count.index).account_name}"
   pattern        = "{ (($.eventName = CreateCustomerGateway) || ($.eventName = DeleteCustomerGateway) || ($.eventName = AttachInternetGateway) || ($.eventName = CreateInternetGateway) || ($.eventName = DeleteInternetGateway) || ($.eventName = DetachInternetGateway)) && ($.userIdentity.accountId = ${element(var.accounts, count.index).account_id}) }"
   log_group_name = var.cloudtrail_log_group_name
 
@@ -443,7 +443,7 @@ resource "aws_cloudwatch_metric_alarm" "network_gw_changes" {
 resource "aws_cloudwatch_log_metric_filter" "route_table_changes" {
   count = var.route_table_changes ? length(var.accounts) : 0
 
-  name           = "RouteTableChanges ${element(var.accounts, count.index).account_name}"
+  name           = "RouteTableChanges-${element(var.accounts, count.index).account_name}"
   pattern        = "{ (($.eventName = CreateRoute) || ($.eventName = CreateRouteTable) || ($.eventName = ReplaceRoute) || ($.eventName = ReplaceRouteTableAssociation) || ($.eventName = DeleteRouteTable) || ($.eventName = DeleteRoute) || ($.eventName = DisassociateRouteTable)) && ($.userIdentity.accountId = ${element(var.accounts, count.index).account_id}) }"
   log_group_name = var.cloudtrail_log_group_name
 
@@ -478,7 +478,7 @@ resource "aws_cloudwatch_metric_alarm" "route_table_changes" {
 resource "aws_cloudwatch_log_metric_filter" "vpc_changes" {
   count = var.vpc_changes ? length(var.accounts) : 0
 
-  name           = "VPCChanges ${element(var.accounts, count.index).account_name}"
+  name           = "VPCChanges-${element(var.accounts, count.index).account_name}"
   pattern        = "{ ${local.vpc_changes_pattern} && ($.userIdentity.accountId = ${element(var.accounts, count.index).account_id}) }"
   log_group_name = var.cloudtrail_log_group_name
 

--- a/main.tf
+++ b/main.tf
@@ -1,8 +1,15 @@
+locals {
+  iam_changes_pattern = "(($.eventName=DeleteGroupPolicy) || ($.eventName=DeleteRolePolicy )| |($.eventName=DeleteUserPolicy) || ($.eventName=PutGroupPolicy) || ($.eventName=PutRolePolicy) || ($.eventName=PutUserPolicy) || ($.eventName=CreatePolicy) || ($.eventName=DeletePolicy) || ($.eventName=CreatePolicyVersion) || ($.eventName=DeletePolicyVersion) || ($.eventName=AttachRolePolicy) || ($.eventName=DetachRolePolicy) || ($.eventName=AttachUserPolicy) || ($.eventName=DetachUserPolicy) || ($.eventName=AttachGroupPolicy) || ($.eventName=DetachGroupPolicy))"
+
+  vpc_changes_pattern = "(($.eventName = CreateVpc) || ($.eventName = DeleteVpc) || ($.eventName = ModifyVpcAttribute) || ($.eventName = AcceptVpcPeeringConnection) || ($.eventName = CreateVpcPeeringConnection) || ($.eventName = DeleteVpcPeeringConnection) || ($.eventName = RejectVpcPeeringConnection) || ($.eventName = AttachClassicLinkVpc) || ($.eventName = DetachClassicLinkVpc) || ($.eventName = DisableVpcClassicLink) || ($.eventName = EnableVpcClassicLink))"
+
+}
+
 resource "aws_cloudwatch_log_metric_filter" "unauthorized_api_calls" {
   count = var.unauthorized_api_calls ? length(var.accounts) : 0
 
-  name           = "UnauthorizedAPICalls: ${element(var.accounts, count.index).account_name}"
-  pattern        = "{ ($.errorCode = \"*UnauthorizedOperation\" && $.userIdentity.accountId = ${element(var.accounts, count.index).account_id}) || ($.errorCode = \"AccessDenied*\" && $.userIdentity.accountId = ${element(var.accounts, count.index).account_id}) }"
+  name           = "UnauthorizedAPICalls ${element(var.accounts, count.index).account_name}"
+  pattern        = "{ (($.errorCode = \"*UnauthorizedOperation\") || ($.errorCode = \"AccessDenied*\")) && ($.userIdentity.accountId = ${element(var.accounts, count.index).account_id}) }"
   log_group_name = var.cloudtrail_log_group_name
 
   metric_transformation {
@@ -15,7 +22,7 @@ resource "aws_cloudwatch_log_metric_filter" "unauthorized_api_calls" {
 resource "aws_cloudwatch_metric_alarm" "unauthorized_api_calls" {
   count = var.unauthorized_api_calls ? length(var.accounts) : 0
 
-  alarm_name                = "UnauthorizedAPICalls: ${element(var.accounts, count.index).account_name}"
+  alarm_name                = "UnauthorizedAPICalls ${element(var.accounts, count.index).account_name}"
   comparison_operator       = "GreaterThanOrEqualToThreshold"
   evaluation_periods        = "1"
   metric_name               = aws_cloudwatch_log_metric_filter.unauthorized_api_calls[0].id
@@ -36,8 +43,8 @@ resource "aws_cloudwatch_metric_alarm" "unauthorized_api_calls" {
 resource "aws_cloudwatch_log_metric_filter" "no_mfa_console_signin_assumed_role" {
   count = var.no_mfa_console_login && ! var.disable_assumed_role_login_alerts ? length(var.accounts) : 0
 
-  name           = "NoMFAConsoleSignin: ${element(var.accounts, count.index).account_name}"
-  pattern        = "{ ($.eventName = \"ConsoleLogin\") && ($.additionalEventData.MFAUsed != \"Yes\" && $.userIdentity.accountId = ${element(var.accounts, count.index).account_id}) }"
+  name           = "NoMFAConsoleSignin ${element(var.accounts, count.index).account_name}"
+  pattern        = "{ ($.eventName = \"ConsoleLogin\") && ($.additionalEventData.MFAUsed != \"Yes\") && ($.userIdentity.accountId = ${element(var.accounts, count.index).account_id}) }"
   log_group_name = var.cloudtrail_log_group_name
 
   metric_transformation {
@@ -50,8 +57,9 @@ resource "aws_cloudwatch_log_metric_filter" "no_mfa_console_signin_assumed_role"
 resource "aws_cloudwatch_log_metric_filter" "no_mfa_console_signin_no_assumed_role" {
   count = var.no_mfa_console_login && var.disable_assumed_role_login_alerts ? length(var.accounts) : 0
 
-  name           = "NoMFAConsoleSignin: ${element(var.accounts, count.index).account_name}"
-  pattern        = "{ ($.eventName = \"ConsoleLogin\") && ($.additionalEventData.MFAUsed != \"Yes\") && ($.userIdentity.arn != \"*assumed-role*\") && ($.userIdentity.accountId = ${element(var.accounts, count.index).account_id}) }"
+  name    = "NoMFAConsoleSignin ${element(var.accounts, count.index).account_name}"
+  pattern = "{ ($.eventName = \"ConsoleLogin\") && ($.additionalEventData.MFAUsed != \"Yes\") && ($.userIdentity.arn != \"*assumed-role*\") && ($.userIdentity.accountId = ${element(var.accounts, count.index).account_id}) }"
+
   log_group_name = var.cloudtrail_log_group_name
 
   metric_transformation {
@@ -64,7 +72,7 @@ resource "aws_cloudwatch_log_metric_filter" "no_mfa_console_signin_no_assumed_ro
 resource "aws_cloudwatch_metric_alarm" "no_mfa_console_signin" {
   count = var.no_mfa_console_login ? length(var.accounts) : 0
 
-  alarm_name                = "NoMFAConsoleSignin: ${element(var.accounts, count.index).account_name}"
+  alarm_name                = "NoMFAConsoleSignin ${element(var.accounts, count.index).account_name}"
   comparison_operator       = "GreaterThanOrEqualToThreshold"
   evaluation_periods        = "1"
   metric_name               = var.disable_assumed_role_login_alerts ? aws_cloudwatch_log_metric_filter.no_mfa_console_signin_no_assumed_role[0].id : aws_cloudwatch_log_metric_filter.no_mfa_console_signin_assumed_role[0].id
@@ -85,7 +93,7 @@ resource "aws_cloudwatch_metric_alarm" "no_mfa_console_signin" {
 resource "aws_cloudwatch_log_metric_filter" "root_usage" {
   count = var.root_usage ? length(var.accounts) : 0
 
-  name           = "RootUsage: ${element(var.accounts, count.index).account_name}"
+  name           = "RootUsage ${element(var.accounts, count.index).account_name}"
   pattern        = "{ $.userIdentity.type = \"Root\" && $.userIdentity.invokedBy NOT EXISTS && $.eventType != \"AwsServiceEvent\" && $.userIdentity.accountId = ${element(var.accounts, count.index).account_id} }"
   log_group_name = var.cloudtrail_log_group_name
 
@@ -99,7 +107,7 @@ resource "aws_cloudwatch_log_metric_filter" "root_usage" {
 resource "aws_cloudwatch_metric_alarm" "root_usage" {
   count = var.root_usage ? length(var.accounts) : 0
 
-  alarm_name                = "RootUsage: ${element(var.accounts, count.index).account_name}"
+  alarm_name                = "RootUsage ${element(var.accounts, count.index).account_name}"
   comparison_operator       = "GreaterThanOrEqualToThreshold"
   evaluation_periods        = "1"
   metric_name               = aws_cloudwatch_log_metric_filter.root_usage[0].id
@@ -120,8 +128,8 @@ resource "aws_cloudwatch_metric_alarm" "root_usage" {
 resource "aws_cloudwatch_log_metric_filter" "iam_changes" {
   count = var.iam_changes ? length(var.accounts) : 0
 
-  name           = "IAMChanges: ${element(var.accounts, count.index).account_name}"
-  pattern        = "{($.eventName=DeleteGroupPolicy && $.userIdentity.accountId = ${element(var.accounts, count.index).account_id})||($.eventName=DeleteRolePolicy && $.userIdentity.accountId = ${element(var.accounts, count.index).account_id})||($.eventName=DeleteUserPolicy && $.userIdentity.accountId = ${element(var.accounts, count.index).account_id})||($.eventName=PutGroupPolicy && $.userIdentity.accountId = ${element(var.accounts, count.index).account_id})||($.eventName=PutRolePolicy && $.userIdentity.accountId = ${element(var.accounts, count.index).account_id})||($.eventName=PutUserPolicy && $.userIdentity.accountId = ${element(var.accounts, count.index).account_id})||($.eventName=CreatePolicy && $.userIdentity.accountId = ${element(var.accounts, count.index).account_id})||($.eventName=DeletePolicy && $.userIdentity.accountId = ${element(var.accounts, count.index).account_id})||($.eventName=CreatePolicyVersion && $.userIdentity.accountId = ${element(var.accounts, count.index).account_id})||($.eventName=DeletePolicyVersion && $.userIdentity.accountId = ${element(var.accounts, count.index).account_id})||($.eventName=AttachRolePolicy && $.userIdentity.accountId = ${element(var.accounts, count.index).account_id})||($.eventName=DetachRolePolicy && $.userIdentity.accountId = ${element(var.accounts, count.index).account_id})||($.eventName=AttachUserPolicy && $.userIdentity.accountId = ${element(var.accounts, count.index).account_id})||($.eventName=DetachUserPolicy && $.userIdentity.accountId = ${element(var.accounts, count.index).account_id})||($.eventName=AttachGroupPolicy && $.userIdentity.accountId = ${element(var.accounts, count.index).account_id})||($.eventName=DetachGroupPolicy && $.userIdentity.accountId = ${element(var.accounts, count.index).account_id})}"
+  name           = "IAMChangesAccount ${element(var.accounts, count.index).account_name}"
+  pattern        = "{ ${local.iam_changes_pattern} && ($.userIdentity.accountId = ${element(var.accounts, count.index).account_id}) }"
   log_group_name = var.cloudtrail_log_group_name
 
   metric_transformation {
@@ -134,7 +142,7 @@ resource "aws_cloudwatch_log_metric_filter" "iam_changes" {
 resource "aws_cloudwatch_metric_alarm" "iam_changes" {
   count = var.iam_changes ? length(var.accounts) : 0
 
-  alarm_name                = "IAMChanges: ${element(var.accounts, count.index).account_name}"
+  alarm_name                = "IAMChangesAccount ${element(var.accounts, count.index).account_name}"
   comparison_operator       = "GreaterThanOrEqualToThreshold"
   evaluation_periods        = "1"
   metric_name               = aws_cloudwatch_log_metric_filter.iam_changes[0].id
@@ -155,8 +163,8 @@ resource "aws_cloudwatch_metric_alarm" "iam_changes" {
 resource "aws_cloudwatch_log_metric_filter" "cloudtrail_cfg_changes" {
   count = var.cloudtrail_cfg_changes ? length(var.accounts) : 0
 
-  name           = "CloudTrailCfgChanges: ${element(var.accounts, count.index).account_name}"
-  pattern        = "{ ($.eventName = CreateTrail && $.userIdentity.accountId = ${element(var.accounts, count.index).account_id}) || ($.eventName = UpdateTrail && $.userIdentity.accountId = ${element(var.accounts, count.index).account_id}) || ($.eventName = DeleteTrail && $.userIdentity.accountId = ${element(var.accounts, count.index).account_id}) || ($.eventName = StartLogging && $.userIdentity.accountId = ${element(var.accounts, count.index).account_id}) || ($.eventName = StopLogging && $.userIdentity.accountId = ${element(var.accounts, count.index).account_id}) }"
+  name           = "CloudTrailCfgChanges ${element(var.accounts, count.index).account_name}"
+  pattern        = "{ (($.eventName = CreateTrail) || ($.eventName = UpdateTrail) || ($.eventName = DeleteTrail) || ($.eventName = StartLogging) || ($.eventName = StopLogging)) && ($.userIdentity.accountId = ${element(var.accounts, count.index).account_id}) }"
   log_group_name = var.cloudtrail_log_group_name
 
   metric_transformation {
@@ -169,7 +177,7 @@ resource "aws_cloudwatch_log_metric_filter" "cloudtrail_cfg_changes" {
 resource "aws_cloudwatch_metric_alarm" "cloudtrail_cfg_changes" {
   count = var.cloudtrail_cfg_changes ? length(var.accounts) : 0
 
-  alarm_name                = "CloudTrailCfgChanges: ${element(var.accounts, count.index).account_name}"
+  alarm_name                = "CloudTrailCfgChanges ${element(var.accounts, count.index).account_name}"
   comparison_operator       = "GreaterThanOrEqualToThreshold"
   evaluation_periods        = "1"
   metric_name               = aws_cloudwatch_log_metric_filter.cloudtrail_cfg_changes[0].id
@@ -190,7 +198,7 @@ resource "aws_cloudwatch_metric_alarm" "cloudtrail_cfg_changes" {
 resource "aws_cloudwatch_log_metric_filter" "console_signin_failures" {
   count = var.console_signin_failures ? length(var.accounts) : 0
 
-  name           = "ConsoleSigninFailures: ${element(var.accounts, count.index).account_name}"
+  name           = "ConsoleSigninFailures ${element(var.accounts, count.index).account_name}"
   pattern        = "{ ($.eventName = ConsoleLogin) && ($.errorMessage = \"Failed authentication\") && ($.userIdentity.accountId = ${element(var.accounts, count.index).account_id}) }"
   log_group_name = var.cloudtrail_log_group_name
 
@@ -204,7 +212,7 @@ resource "aws_cloudwatch_log_metric_filter" "console_signin_failures" {
 resource "aws_cloudwatch_metric_alarm" "console_signin_failures" {
   count = var.console_signin_failures ? length(var.accounts) : 0
 
-  alarm_name                = "ConsoleSigninFailures: ${element(var.accounts, count.index).account_name}"
+  alarm_name                = "ConsoleSigninFailures ${element(var.accounts, count.index).account_name}"
   comparison_operator       = "GreaterThanOrEqualToThreshold"
   evaluation_periods        = "1"
   metric_name               = aws_cloudwatch_log_metric_filter.console_signin_failures[0].id
@@ -225,7 +233,7 @@ resource "aws_cloudwatch_metric_alarm" "console_signin_failures" {
 resource "aws_cloudwatch_log_metric_filter" "disable_or_delete_cmk" {
   count = var.disable_or_delete_cmk ? length(var.accounts) : 0
 
-  name           = "DisableOrDeleteCMK: ${element(var.accounts, count.index).account_name}"
+  name           = "DisableOrDeleteCMK ${element(var.accounts, count.index).account_name}"
   pattern        = "{ ($.eventSource = kms.amazonaws.com) && (($.eventName = DisableKey) || ($.eventName = ScheduleKeyDeletion)) && ($.userIdentity.accountId = ${element(var.accounts, count.index).account_id}) }"
   log_group_name = var.cloudtrail_log_group_name
 
@@ -239,7 +247,7 @@ resource "aws_cloudwatch_log_metric_filter" "disable_or_delete_cmk" {
 resource "aws_cloudwatch_metric_alarm" "disable_or_delete_cmk" {
   count = var.disable_or_delete_cmk ? length(var.accounts) : 0
 
-  alarm_name                = "DisableOrDeleteCMK: ${element(var.accounts, count.index).account_name}"
+  alarm_name                = "DisableOrDeleteCMK ${element(var.accounts, count.index).account_name}"
   comparison_operator       = "GreaterThanOrEqualToThreshold"
   evaluation_periods        = "1"
   metric_name               = aws_cloudwatch_log_metric_filter.disable_or_delete_cmk[0].id
@@ -260,7 +268,7 @@ resource "aws_cloudwatch_metric_alarm" "disable_or_delete_cmk" {
 resource "aws_cloudwatch_log_metric_filter" "s3_bucket_policy_changes" {
   count = var.s3_bucket_policy_changes ? length(var.accounts) : 0
 
-  name           = "S3BucketPolicyChanges: ${element(var.accounts, count.index).account_name}"
+  name           = "S3BucketPolicyChanges ${element(var.accounts, count.index).account_name}"
   pattern        = "{ ($.eventSource = s3.amazonaws.com) && (($.eventName = PutBucketAcl) || ($.eventName = PutBucketPolicy) || ($.eventName = PutBucketCors) || ($.eventName = PutBucketLifecycle) || ($.eventName = PutBucketReplication) || ($.eventName = DeleteBucketPolicy) || ($.eventName = DeleteBucketCors) || ($.eventName = DeleteBucketLifecycle) || ($.eventName = DeleteBucketReplication)) && ($.userIdentity.accountId = ${element(var.accounts, count.index).account_id}) }"
   log_group_name = var.cloudtrail_log_group_name
 
@@ -274,7 +282,7 @@ resource "aws_cloudwatch_log_metric_filter" "s3_bucket_policy_changes" {
 resource "aws_cloudwatch_metric_alarm" "s3_bucket_policy_changes" {
   count = var.s3_bucket_policy_changes ? length(var.accounts) : 0
 
-  alarm_name                = "S3BucketPolicyChanges: ${element(var.accounts, count.index).account_name}"
+  alarm_name                = "S3BucketPolicyChanges ${element(var.accounts, count.index).account_name}"
   comparison_operator       = "GreaterThanOrEqualToThreshold"
   evaluation_periods        = "1"
   metric_name               = aws_cloudwatch_log_metric_filter.s3_bucket_policy_changes[0].id
@@ -295,7 +303,7 @@ resource "aws_cloudwatch_metric_alarm" "s3_bucket_policy_changes" {
 resource "aws_cloudwatch_log_metric_filter" "aws_config_changes" {
   count = var.aws_config_changes ? length(var.accounts) : 0
 
-  name           = "AWSConfigChanges: ${element(var.accounts, count.index).account_name}"
+  name           = "AWSConfigChanges ${element(var.accounts, count.index).account_name}"
   pattern        = "{ ($.eventSource = config.amazonaws.com) && (($.eventName=StopConfigurationRecorder)||($.eventName=DeleteDeliveryChannel)||($.eventName=PutDeliveryChannel)||($.eventName=PutConfigurationRecorder)) && ($.userIdentity.accountId = ${element(var.accounts, count.index).account_id}) }"
   log_group_name = var.cloudtrail_log_group_name
 
@@ -309,7 +317,7 @@ resource "aws_cloudwatch_log_metric_filter" "aws_config_changes" {
 resource "aws_cloudwatch_metric_alarm" "aws_config_changes" {
   count = var.aws_config_changes ? length(var.accounts) : 0
 
-  alarm_name                = "AWSConfigChanges: ${element(var.accounts, count.index).account_name}"
+  alarm_name                = "AWSConfigChanges ${element(var.accounts, count.index).account_name}"
   comparison_operator       = "GreaterThanOrEqualToThreshold"
   evaluation_periods        = "1"
   metric_name               = aws_cloudwatch_log_metric_filter.aws_config_changes[0].id
@@ -330,8 +338,8 @@ resource "aws_cloudwatch_metric_alarm" "aws_config_changes" {
 resource "aws_cloudwatch_log_metric_filter" "security_group_changes" {
   count = var.security_group_changes ? length(var.accounts) : 0
 
-  name           = "SecurityGroupChanges: ${element(var.accounts, count.index).account_name}"
-  pattern        = "{ ($.eventName = AuthorizeSecurityGroupIngress && $.userIdentity.accountId = ${element(var.accounts, count.index).account_id}) || ($.eventName = AuthorizeSecurityGroupEgress && $.userIdentity.accountId = ${element(var.accounts, count.index).account_id}) || ($.eventName = RevokeSecurityGroupIngress && $.userIdentity.accountId = ${element(var.accounts, count.index).account_id}) || ($.eventName = RevokeSecurityGroupEgress && $.userIdentity.accountId = ${element(var.accounts, count.index).account_id}) || ($.eventName = CreateSecurityGroup && $.userIdentity.accountId = ${element(var.accounts, count.index).account_id}) || ($.eventName = DeleteSecurityGroup && $.userIdentity.accountId = ${element(var.accounts, count.index).account_id})}"
+  name           = "SecurityGroupChanges ${element(var.accounts, count.index).account_name}"
+  pattern        = "{ (($.eventName = AuthorizeSecurityGroupIngress) || ($.eventName = AuthorizeSecurityGroupEgress) || ($.eventName = RevokeSecurityGroupIngress) || ($.eventName = RevokeSecurityGroupEgress) || ($.eventName = CreateSecurityGroup) || ($.eventName = DeleteSecurityGroup)) && ($.userIdentity.accountId = ${element(var.accounts, count.index).account_id})}"
   log_group_name = var.cloudtrail_log_group_name
 
   metric_transformation {
@@ -344,7 +352,7 @@ resource "aws_cloudwatch_log_metric_filter" "security_group_changes" {
 resource "aws_cloudwatch_metric_alarm" "security_group_changes" {
   count = var.security_group_changes ? length(var.accounts) : 0
 
-  alarm_name                = "SecurityGroupChanges: ${element(var.accounts, count.index).account_name}"
+  alarm_name                = "SecurityGroupChanges ${element(var.accounts, count.index).account_name}"
   comparison_operator       = "GreaterThanOrEqualToThreshold"
   evaluation_periods        = "1"
   metric_name               = aws_cloudwatch_log_metric_filter.security_group_changes[0].id
@@ -365,8 +373,8 @@ resource "aws_cloudwatch_metric_alarm" "security_group_changes" {
 resource "aws_cloudwatch_log_metric_filter" "nacl_changes" {
   count = var.nacl_changes ? length(var.accounts) : 0
 
-  name           = "NACLChanges: ${element(var.accounts, count.index).account_name}"
-  pattern        = "{ ($.eventName = CreateNetworkAcl && $.userIdentity.accountId = ${element(var.accounts, count.index).account_id}) || ($.eventName = CreateNetworkAclEntry && $.userIdentity.accountId = ${element(var.accounts, count.index).account_id}) || ($.eventName = DeleteNetworkAcl && $.userIdentity.accountId = ${element(var.accounts, count.index).account_id}) || ($.eventName = DeleteNetworkAclEntry && $.userIdentity.accountId = ${element(var.accounts, count.index).account_id}) || ($.eventName = ReplaceNetworkAclEntry && $.userIdentity.accountId = ${element(var.accounts, count.index).account_id}) || ($.eventName = ReplaceNetworkAclAssociation && $.userIdentity.accountId = ${element(var.accounts, count.index).account_id}) }"
+  name           = "NACLChanges ${element(var.accounts, count.index).account_name}"
+  pattern        = "{ (($.eventName = CreateNetworkAcl) || ($.eventName = CreateNetworkAclEntry) || ($.eventName = DeleteNetworkAcl) || ($.eventName = DeleteNetworkAclEntry) || ($.eventName = ReplaceNetworkAclEntry) || ($.eventName = ReplaceNetworkAclAssociation)) && ($.userIdentity.accountId = ${element(var.accounts, count.index).account_id}) }"
   log_group_name = var.cloudtrail_log_group_name
 
   metric_transformation {
@@ -379,7 +387,7 @@ resource "aws_cloudwatch_log_metric_filter" "nacl_changes" {
 resource "aws_cloudwatch_metric_alarm" "nacl_changes" {
   count = var.nacl_changes ? length(var.accounts) : 0
 
-  alarm_name                = "NACLChanges: ${element(var.accounts, count.index).account_name}"
+  alarm_name                = "NACLChanges ${element(var.accounts, count.index).account_name}"
   comparison_operator       = "GreaterThanOrEqualToThreshold"
   evaluation_periods        = "1"
   metric_name               = aws_cloudwatch_log_metric_filter.nacl_changes[0].id
@@ -400,8 +408,8 @@ resource "aws_cloudwatch_metric_alarm" "nacl_changes" {
 resource "aws_cloudwatch_log_metric_filter" "network_gw_changes" {
   count = var.network_gw_changes ? length(var.accounts) : 0
 
-  name           = "NetworkGWChanges: ${element(var.accounts, count.index).account_name}"
-  pattern        = "{ ($.eventName = CreateCustomerGateway && $.userIdentity.accountId = ${element(var.accounts, count.index).account_id}) || ($.eventName = DeleteCustomerGateway && $.userIdentity.accountId = ${element(var.accounts, count.index).account_id}) || ($.eventName = AttachInternetGateway && $.userIdentity.accountId = ${element(var.accounts, count.index).account_id}) || ($.eventName = CreateInternetGateway && $.userIdentity.accountId = ${element(var.accounts, count.index).account_id}) || ($.eventName = DeleteInternetGateway && $.userIdentity.accountId = ${element(var.accounts, count.index).account_id}) || ($.eventName = DetachInternetGateway && $.userIdentity.accountId = ${element(var.accounts, count.index).account_id}) }"
+  name           = "NetworkGWChanges ${element(var.accounts, count.index).account_name}"
+  pattern        = "{ (($.eventName = CreateCustomerGateway) || ($.eventName = DeleteCustomerGateway) || ($.eventName = AttachInternetGateway) || ($.eventName = CreateInternetGateway) || ($.eventName = DeleteInternetGateway) || ($.eventName = DetachInternetGateway)) && ($.userIdentity.accountId = ${element(var.accounts, count.index).account_id}) }"
   log_group_name = var.cloudtrail_log_group_name
 
   metric_transformation {
@@ -414,7 +422,7 @@ resource "aws_cloudwatch_log_metric_filter" "network_gw_changes" {
 resource "aws_cloudwatch_metric_alarm" "network_gw_changes" {
   count = var.network_gw_changes ? length(var.accounts) : 0
 
-  alarm_name                = "NetworkGWChanges: ${element(var.accounts, count.index).account_name}"
+  alarm_name                = "NetworkGWChanges ${element(var.accounts, count.index).account_name}"
   comparison_operator       = "GreaterThanOrEqualToThreshold"
   evaluation_periods        = "1"
   metric_name               = aws_cloudwatch_log_metric_filter.network_gw_changes[0].id
@@ -435,8 +443,8 @@ resource "aws_cloudwatch_metric_alarm" "network_gw_changes" {
 resource "aws_cloudwatch_log_metric_filter" "route_table_changes" {
   count = var.route_table_changes ? length(var.accounts) : 0
 
-  name           = "RouteTableChanges: ${element(var.accounts, count.index).account_name}"
-  pattern        = "{ ($.eventName = CreateRoute && $.userIdentity.accountId = ${element(var.accounts, count.index).account_id}) || ($.eventName = CreateRouteTable && $.userIdentity.accountId = ${element(var.accounts, count.index).account_id}) || ($.eventName = ReplaceRoute && $.userIdentity.accountId = ${element(var.accounts, count.index).account_id}) || ($.eventName = ReplaceRouteTableAssociation && $.userIdentity.accountId = ${element(var.accounts, count.index).account_id}) || ($.eventName = DeleteRouteTable && $.userIdentity.accountId = ${element(var.accounts, count.index).account_id}) || ($.eventName = DeleteRoute && $.userIdentity.accountId = ${element(var.accounts, count.index).account_id}) || ($.eventName = DisassociateRouteTable && $.userIdentity.accountId = ${element(var.accounts, count.index).account_id}) }"
+  name           = "RouteTableChanges ${element(var.accounts, count.index).account_name}"
+  pattern        = "{ (($.eventName = CreateRoute) || ($.eventName = CreateRouteTable) || ($.eventName = ReplaceRoute) || ($.eventName = ReplaceRouteTableAssociation) || ($.eventName = DeleteRouteTable) || ($.eventName = DeleteRoute) || ($.eventName = DisassociateRouteTable)) && ($.userIdentity.accountId = ${element(var.accounts, count.index).account_id}) }"
   log_group_name = var.cloudtrail_log_group_name
 
   metric_transformation {
@@ -449,7 +457,7 @@ resource "aws_cloudwatch_log_metric_filter" "route_table_changes" {
 resource "aws_cloudwatch_metric_alarm" "route_table_changes" {
   count = var.route_table_changes ? length(var.accounts) : 0
 
-  alarm_name                = "RouteTableChanges: ${element(var.accounts, count.index).account_name}"
+  alarm_name                = "RouteTableChanges ${element(var.accounts, count.index).account_name}"
   comparison_operator       = "GreaterThanOrEqualToThreshold"
   evaluation_periods        = "1"
   metric_name               = aws_cloudwatch_log_metric_filter.route_table_changes[0].id
@@ -470,8 +478,8 @@ resource "aws_cloudwatch_metric_alarm" "route_table_changes" {
 resource "aws_cloudwatch_log_metric_filter" "vpc_changes" {
   count = var.vpc_changes ? length(var.accounts) : 0
 
-  name           = "VPCChanges: ${element(var.accounts, count.index).account_name}"
-  pattern        = "{ ($.eventName = CreateVpc && $.userIdentity.accountId = ${element(var.accounts, count.index).account_id}) || ($.eventName = DeleteVpc && $.userIdentity.accountId = ${element(var.accounts, count.index).account_id}) || ($.eventName = ModifyVpcAttribute && $.userIdentity.accountId = ${element(var.accounts, count.index).account_id}) || ($.eventName = AcceptVpcPeeringConnection && $.userIdentity.accountId = ${element(var.accounts, count.index).account_id}) || ($.eventName = CreateVpcPeeringConnection && $.userIdentity.accountId = ${element(var.accounts, count.index).account_id}) || ($.eventName = DeleteVpcPeeringConnection && $.userIdentity.accountId = ${element(var.accounts, count.index).account_id}) || ($.eventName = RejectVpcPeeringConnection && $.userIdentity.accountId = ${element(var.accounts, count.index).account_id}) || ($.eventName = AttachClassicLinkVpc && $.userIdentity.accountId = ${element(var.accounts, count.index).account_id}) || ($.eventName = DetachClassicLinkVpc && $.userIdentity.accountId = ${element(var.accounts, count.index).account_id}) || ($.eventName = DisableVpcClassicLink && $.userIdentity.accountId = ${element(var.accounts, count.index).account_id}) || ($.eventName = EnableVpcClassicLink && $.userIdentity.accountId = ${element(var.accounts, count.index).account_id}) }"
+  name           = "VPCChanges ${element(var.accounts, count.index).account_name}"
+  pattern        = "{ ${local.vpc_changes_pattern} && ($.userIdentity.accountId = ${element(var.accounts, count.index).account_id}) }"
   log_group_name = var.cloudtrail_log_group_name
 
   metric_transformation {
@@ -484,7 +492,7 @@ resource "aws_cloudwatch_log_metric_filter" "vpc_changes" {
 resource "aws_cloudwatch_metric_alarm" "vpc_changes" {
   count = var.vpc_changes ? length(var.accounts) : 0
 
-  alarm_name                = "VPCChanges: ${element(var.accounts, count.index).account_name}"
+  alarm_name                = "VPCChanges ${element(var.accounts, count.index).account_name}"
   comparison_operator       = "GreaterThanOrEqualToThreshold"
   evaluation_periods        = "1"
   metric_name               = aws_cloudwatch_log_metric_filter.vpc_changes[0].id

--- a/main.tf
+++ b/main.tf
@@ -22,7 +22,7 @@ resource "aws_cloudwatch_log_metric_filter" "unauthorized_api_calls" {
 resource "aws_cloudwatch_metric_alarm" "unauthorized_api_calls" {
   count = var.unauthorized_api_calls ? length(var.accounts) : 0
 
-  alarm_name                = "UnauthorizedAPICalls ${element(var.accounts, count.index).account_name}"
+  alarm_name                = "UnauthorizedAPICalls for ${element(var.accounts, count.index).account_name} account"
   comparison_operator       = "GreaterThanOrEqualToThreshold"
   evaluation_periods        = "1"
   metric_name               = aws_cloudwatch_log_metric_filter.unauthorized_api_calls[0].id
@@ -72,7 +72,7 @@ resource "aws_cloudwatch_log_metric_filter" "no_mfa_console_signin_no_assumed_ro
 resource "aws_cloudwatch_metric_alarm" "no_mfa_console_signin" {
   count = var.no_mfa_console_login ? length(var.accounts) : 0
 
-  alarm_name                = "NoMFAConsoleSignin ${element(var.accounts, count.index).account_name}"
+  alarm_name                = "NoMFAConsoleSignin for ${element(var.accounts, count.index).account_name} account"
   comparison_operator       = "GreaterThanOrEqualToThreshold"
   evaluation_periods        = "1"
   metric_name               = var.disable_assumed_role_login_alerts ? aws_cloudwatch_log_metric_filter.no_mfa_console_signin_no_assumed_role[0].id : aws_cloudwatch_log_metric_filter.no_mfa_console_signin_assumed_role[0].id
@@ -107,7 +107,7 @@ resource "aws_cloudwatch_log_metric_filter" "root_usage" {
 resource "aws_cloudwatch_metric_alarm" "root_usage" {
   count = var.root_usage ? length(var.accounts) : 0
 
-  alarm_name                = "RootUsage ${element(var.accounts, count.index).account_name}"
+  alarm_name                = "RootUsage for ${element(var.accounts, count.index).account_name} account"
   comparison_operator       = "GreaterThanOrEqualToThreshold"
   evaluation_periods        = "1"
   metric_name               = aws_cloudwatch_log_metric_filter.root_usage[0].id
@@ -128,7 +128,7 @@ resource "aws_cloudwatch_metric_alarm" "root_usage" {
 resource "aws_cloudwatch_log_metric_filter" "iam_changes" {
   count = var.iam_changes ? length(var.accounts) : 0
 
-  name           = "IAMChangesAccount ${element(var.accounts, count.index).account_name}"
+  name           = "IAMChanges ${element(var.accounts, count.index).account_name}"
   pattern        = "{ ${local.iam_changes_pattern} && ($.userIdentity.accountId = ${element(var.accounts, count.index).account_id}) }"
   log_group_name = var.cloudtrail_log_group_name
 
@@ -142,7 +142,7 @@ resource "aws_cloudwatch_log_metric_filter" "iam_changes" {
 resource "aws_cloudwatch_metric_alarm" "iam_changes" {
   count = var.iam_changes ? length(var.accounts) : 0
 
-  alarm_name                = "IAMChangesAccount ${element(var.accounts, count.index).account_name}"
+  alarm_name                = "IAMChanges for ${element(var.accounts, count.index).account_name} account"
   comparison_operator       = "GreaterThanOrEqualToThreshold"
   evaluation_periods        = "1"
   metric_name               = aws_cloudwatch_log_metric_filter.iam_changes[0].id
@@ -177,7 +177,7 @@ resource "aws_cloudwatch_log_metric_filter" "cloudtrail_cfg_changes" {
 resource "aws_cloudwatch_metric_alarm" "cloudtrail_cfg_changes" {
   count = var.cloudtrail_cfg_changes ? length(var.accounts) : 0
 
-  alarm_name                = "CloudTrailCfgChanges ${element(var.accounts, count.index).account_name}"
+  alarm_name                = "CloudTrailCfgChanges for ${element(var.accounts, count.index).account_name} account"
   comparison_operator       = "GreaterThanOrEqualToThreshold"
   evaluation_periods        = "1"
   metric_name               = aws_cloudwatch_log_metric_filter.cloudtrail_cfg_changes[0].id
@@ -212,7 +212,7 @@ resource "aws_cloudwatch_log_metric_filter" "console_signin_failures" {
 resource "aws_cloudwatch_metric_alarm" "console_signin_failures" {
   count = var.console_signin_failures ? length(var.accounts) : 0
 
-  alarm_name                = "ConsoleSigninFailures ${element(var.accounts, count.index).account_name}"
+  alarm_name                = "ConsoleSigninFailures for ${element(var.accounts, count.index).account_name} account"
   comparison_operator       = "GreaterThanOrEqualToThreshold"
   evaluation_periods        = "1"
   metric_name               = aws_cloudwatch_log_metric_filter.console_signin_failures[0].id
@@ -247,7 +247,7 @@ resource "aws_cloudwatch_log_metric_filter" "disable_or_delete_cmk" {
 resource "aws_cloudwatch_metric_alarm" "disable_or_delete_cmk" {
   count = var.disable_or_delete_cmk ? length(var.accounts) : 0
 
-  alarm_name                = "DisableOrDeleteCMK ${element(var.accounts, count.index).account_name}"
+  alarm_name                = "DisableOrDeleteCMK for ${element(var.accounts, count.index).account_name} account"
   comparison_operator       = "GreaterThanOrEqualToThreshold"
   evaluation_periods        = "1"
   metric_name               = aws_cloudwatch_log_metric_filter.disable_or_delete_cmk[0].id
@@ -282,7 +282,7 @@ resource "aws_cloudwatch_log_metric_filter" "s3_bucket_policy_changes" {
 resource "aws_cloudwatch_metric_alarm" "s3_bucket_policy_changes" {
   count = var.s3_bucket_policy_changes ? length(var.accounts) : 0
 
-  alarm_name                = "S3BucketPolicyChanges ${element(var.accounts, count.index).account_name}"
+  alarm_name                = "S3BucketPolicyChanges for ${element(var.accounts, count.index).account_name} account"
   comparison_operator       = "GreaterThanOrEqualToThreshold"
   evaluation_periods        = "1"
   metric_name               = aws_cloudwatch_log_metric_filter.s3_bucket_policy_changes[0].id
@@ -317,7 +317,7 @@ resource "aws_cloudwatch_log_metric_filter" "aws_config_changes" {
 resource "aws_cloudwatch_metric_alarm" "aws_config_changes" {
   count = var.aws_config_changes ? length(var.accounts) : 0
 
-  alarm_name                = "AWSConfigChanges ${element(var.accounts, count.index).account_name}"
+  alarm_name                = "AWSConfigChanges for ${element(var.accounts, count.index).account_name} account"
   comparison_operator       = "GreaterThanOrEqualToThreshold"
   evaluation_periods        = "1"
   metric_name               = aws_cloudwatch_log_metric_filter.aws_config_changes[0].id
@@ -352,7 +352,7 @@ resource "aws_cloudwatch_log_metric_filter" "security_group_changes" {
 resource "aws_cloudwatch_metric_alarm" "security_group_changes" {
   count = var.security_group_changes ? length(var.accounts) : 0
 
-  alarm_name                = "SecurityGroupChanges ${element(var.accounts, count.index).account_name}"
+  alarm_name                = "SecurityGroupChanges for ${element(var.accounts, count.index).account_name} account"
   comparison_operator       = "GreaterThanOrEqualToThreshold"
   evaluation_periods        = "1"
   metric_name               = aws_cloudwatch_log_metric_filter.security_group_changes[0].id
@@ -387,7 +387,7 @@ resource "aws_cloudwatch_log_metric_filter" "nacl_changes" {
 resource "aws_cloudwatch_metric_alarm" "nacl_changes" {
   count = var.nacl_changes ? length(var.accounts) : 0
 
-  alarm_name                = "NACLChanges ${element(var.accounts, count.index).account_name}"
+  alarm_name                = "NACLChanges for ${element(var.accounts, count.index).account_name} account"
   comparison_operator       = "GreaterThanOrEqualToThreshold"
   evaluation_periods        = "1"
   metric_name               = aws_cloudwatch_log_metric_filter.nacl_changes[0].id
@@ -422,7 +422,7 @@ resource "aws_cloudwatch_log_metric_filter" "network_gw_changes" {
 resource "aws_cloudwatch_metric_alarm" "network_gw_changes" {
   count = var.network_gw_changes ? length(var.accounts) : 0
 
-  alarm_name                = "NetworkGWChanges ${element(var.accounts, count.index).account_name}"
+  alarm_name                = "NetworkGWChanges for ${element(var.accounts, count.index).account_name} account"
   comparison_operator       = "GreaterThanOrEqualToThreshold"
   evaluation_periods        = "1"
   metric_name               = aws_cloudwatch_log_metric_filter.network_gw_changes[0].id
@@ -457,7 +457,7 @@ resource "aws_cloudwatch_log_metric_filter" "route_table_changes" {
 resource "aws_cloudwatch_metric_alarm" "route_table_changes" {
   count = var.route_table_changes ? length(var.accounts) : 0
 
-  alarm_name                = "RouteTableChanges ${element(var.accounts, count.index).account_name}"
+  alarm_name                = "RouteTableChanges for ${element(var.accounts, count.index).account_name} account"
   comparison_operator       = "GreaterThanOrEqualToThreshold"
   evaluation_periods        = "1"
   metric_name               = aws_cloudwatch_log_metric_filter.route_table_changes[0].id
@@ -492,7 +492,7 @@ resource "aws_cloudwatch_log_metric_filter" "vpc_changes" {
 resource "aws_cloudwatch_metric_alarm" "vpc_changes" {
   count = var.vpc_changes ? length(var.accounts) : 0
 
-  alarm_name                = "VPCChanges ${element(var.accounts, count.index).account_name}"
+  alarm_name                = "VPCChanges for ${element(var.accounts, count.index).account_name} account"
   comparison_operator       = "GreaterThanOrEqualToThreshold"
   evaluation_periods        = "1"
   metric_name               = aws_cloudwatch_log_metric_filter.vpc_changes[0].id

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 locals {
-  iam_changes_pattern = "(($.eventName=DeleteGroupPolicy) || ($.eventName=DeleteRolePolicy )| |($.eventName=DeleteUserPolicy) || ($.eventName=PutGroupPolicy) || ($.eventName=PutRolePolicy) || ($.eventName=PutUserPolicy) || ($.eventName=CreatePolicy) || ($.eventName=DeletePolicy) || ($.eventName=CreatePolicyVersion) || ($.eventName=DeletePolicyVersion) || ($.eventName=AttachRolePolicy) || ($.eventName=DetachRolePolicy) || ($.eventName=AttachUserPolicy) || ($.eventName=DetachUserPolicy) || ($.eventName=AttachGroupPolicy) || ($.eventName=DetachGroupPolicy))"
+  iam_changes_pattern = "(($.eventName=DeleteGroupPolicy) || ($.eventName=DeleteRolePolicy) ||($.eventName=DeleteUserPolicy) || ($.eventName=PutGroupPolicy) || ($.eventName=PutRolePolicy) || ($.eventName=PutUserPolicy) || ($.eventName=CreatePolicy) || ($.eventName=DeletePolicy) || ($.eventName=CreatePolicyVersion) || ($.eventName=DeletePolicyVersion) || ($.eventName=AttachRolePolicy) || ($.eventName=DetachRolePolicy) || ($.eventName=AttachUserPolicy) || ($.eventName=DetachUserPolicy) || ($.eventName=AttachGroupPolicy) || ($.eventName=DetachGroupPolicy))"
 
   vpc_changes_pattern = "(($.eventName = CreateVpc) || ($.eventName = DeleteVpc) || ($.eventName = ModifyVpcAttribute) || ($.eventName = AcceptVpcPeeringConnection) || ($.eventName = CreateVpcPeeringConnection) || ($.eventName = DeleteVpcPeeringConnection) || ($.eventName = RejectVpcPeeringConnection) || ($.eventName = AttachClassicLinkVpc) || ($.eventName = DetachClassicLinkVpc) || ($.eventName = DisableVpcClassicLink) || ($.eventName = EnableVpcClassicLink))"
 
@@ -22,7 +22,7 @@ resource "aws_cloudwatch_log_metric_filter" "unauthorized_api_calls" {
 resource "aws_cloudwatch_metric_alarm" "unauthorized_api_calls" {
   count = var.unauthorized_api_calls ? length(var.accounts) : 0
 
-  alarm_name                = "UnauthorizedAPICalls for ${element(var.accounts, count.index).account_name} account"
+  alarm_name                = "UnauthorizedAPICalls-${element(var.accounts, count.index).account_name}"
   comparison_operator       = "GreaterThanOrEqualToThreshold"
   evaluation_periods        = "1"
   metric_name               = aws_cloudwatch_log_metric_filter.unauthorized_api_calls[0].id
@@ -30,7 +30,7 @@ resource "aws_cloudwatch_metric_alarm" "unauthorized_api_calls" {
   period                    = "300"
   statistic                 = "Sum"
   threshold                 = "1"
-  alarm_description         = "Alert for account ${element(var.accounts, count.index).account_name} (ID: ${element(var.accounts, count.index).account_id}). Alert for account ${element(var.accounts, count.index).account_name} (ID: ${element(var.accounts, count.index).account_id}). Monitoring unauthorized API calls will help reveal application errors and may reduce time to detect malicious activity."
+  alarm_description         = "Alert for account ${element(var.accounts, count.index).account_name} (ID: ${element(var.accounts, count.index).account_id}). Monitoring unauthorized API calls will help reveal application errors and may reduce time to detect malicious activity."
   alarm_actions             = [var.alarm_sns_topic_arn]
   treat_missing_data        = "notBreaching"
   insufficient_data_actions = []
@@ -43,7 +43,7 @@ resource "aws_cloudwatch_metric_alarm" "unauthorized_api_calls" {
 resource "aws_cloudwatch_log_metric_filter" "no_mfa_console_signin_assumed_role" {
   count = var.no_mfa_console_login && ! var.disable_assumed_role_login_alerts ? length(var.accounts) : 0
 
-  name           = "NoMFAConsoleSignin ${element(var.accounts, count.index).account_name}"
+  name           = "NoMFAConsoleSignin-${element(var.accounts, count.index).account_name}"
   pattern        = "{ ($.eventName = \"ConsoleLogin\") && ($.additionalEventData.MFAUsed != \"Yes\") && ($.userIdentity.accountId = ${element(var.accounts, count.index).account_id}) }"
   log_group_name = var.cloudtrail_log_group_name
 
@@ -72,7 +72,7 @@ resource "aws_cloudwatch_log_metric_filter" "no_mfa_console_signin_no_assumed_ro
 resource "aws_cloudwatch_metric_alarm" "no_mfa_console_signin" {
   count = var.no_mfa_console_login ? length(var.accounts) : 0
 
-  alarm_name                = "NoMFAConsoleSignin for ${element(var.accounts, count.index).account_name} account"
+  alarm_name                = "NoMFAConsoleSignin-${element(var.accounts, count.index).account_name}"
   comparison_operator       = "GreaterThanOrEqualToThreshold"
   evaluation_periods        = "1"
   metric_name               = var.disable_assumed_role_login_alerts ? aws_cloudwatch_log_metric_filter.no_mfa_console_signin_no_assumed_role[0].id : aws_cloudwatch_log_metric_filter.no_mfa_console_signin_assumed_role[0].id
@@ -107,7 +107,7 @@ resource "aws_cloudwatch_log_metric_filter" "root_usage" {
 resource "aws_cloudwatch_metric_alarm" "root_usage" {
   count = var.root_usage ? length(var.accounts) : 0
 
-  alarm_name                = "RootUsage for ${element(var.accounts, count.index).account_name} account"
+  alarm_name                = "RootUsage-${element(var.accounts, count.index).account_name}"
   comparison_operator       = "GreaterThanOrEqualToThreshold"
   evaluation_periods        = "1"
   metric_name               = aws_cloudwatch_log_metric_filter.root_usage[0].id
@@ -142,7 +142,7 @@ resource "aws_cloudwatch_log_metric_filter" "iam_changes" {
 resource "aws_cloudwatch_metric_alarm" "iam_changes" {
   count = var.iam_changes ? length(var.accounts) : 0
 
-  alarm_name                = "IAMChanges for ${element(var.accounts, count.index).account_name} account"
+  alarm_name                = "IAMChanges-${element(var.accounts, count.index).account_name}"
   comparison_operator       = "GreaterThanOrEqualToThreshold"
   evaluation_periods        = "1"
   metric_name               = aws_cloudwatch_log_metric_filter.iam_changes[0].id
@@ -177,7 +177,7 @@ resource "aws_cloudwatch_log_metric_filter" "cloudtrail_cfg_changes" {
 resource "aws_cloudwatch_metric_alarm" "cloudtrail_cfg_changes" {
   count = var.cloudtrail_cfg_changes ? length(var.accounts) : 0
 
-  alarm_name                = "CloudTrailCfgChanges for ${element(var.accounts, count.index).account_name} account"
+  alarm_name                = "CloudTrailCfgChanges-${element(var.accounts, count.index).account_name}"
   comparison_operator       = "GreaterThanOrEqualToThreshold"
   evaluation_periods        = "1"
   metric_name               = aws_cloudwatch_log_metric_filter.cloudtrail_cfg_changes[0].id
@@ -212,7 +212,7 @@ resource "aws_cloudwatch_log_metric_filter" "console_signin_failures" {
 resource "aws_cloudwatch_metric_alarm" "console_signin_failures" {
   count = var.console_signin_failures ? length(var.accounts) : 0
 
-  alarm_name                = "ConsoleSigninFailures for ${element(var.accounts, count.index).account_name} account"
+  alarm_name                = "ConsoleSigninFailures-${element(var.accounts, count.index).account_name}"
   comparison_operator       = "GreaterThanOrEqualToThreshold"
   evaluation_periods        = "1"
   metric_name               = aws_cloudwatch_log_metric_filter.console_signin_failures[0].id
@@ -247,7 +247,7 @@ resource "aws_cloudwatch_log_metric_filter" "disable_or_delete_cmk" {
 resource "aws_cloudwatch_metric_alarm" "disable_or_delete_cmk" {
   count = var.disable_or_delete_cmk ? length(var.accounts) : 0
 
-  alarm_name                = "DisableOrDeleteCMK for ${element(var.accounts, count.index).account_name} account"
+  alarm_name                = "DisableOrDeleteCMK-${element(var.accounts, count.index).account_name}"
   comparison_operator       = "GreaterThanOrEqualToThreshold"
   evaluation_periods        = "1"
   metric_name               = aws_cloudwatch_log_metric_filter.disable_or_delete_cmk[0].id
@@ -282,7 +282,7 @@ resource "aws_cloudwatch_log_metric_filter" "s3_bucket_policy_changes" {
 resource "aws_cloudwatch_metric_alarm" "s3_bucket_policy_changes" {
   count = var.s3_bucket_policy_changes ? length(var.accounts) : 0
 
-  alarm_name                = "S3BucketPolicyChanges for ${element(var.accounts, count.index).account_name} account"
+  alarm_name                = "S3BucketPolicyChanges-${element(var.accounts, count.index).account_name}"
   comparison_operator       = "GreaterThanOrEqualToThreshold"
   evaluation_periods        = "1"
   metric_name               = aws_cloudwatch_log_metric_filter.s3_bucket_policy_changes[0].id
@@ -317,7 +317,7 @@ resource "aws_cloudwatch_log_metric_filter" "aws_config_changes" {
 resource "aws_cloudwatch_metric_alarm" "aws_config_changes" {
   count = var.aws_config_changes ? length(var.accounts) : 0
 
-  alarm_name                = "AWSConfigChanges for ${element(var.accounts, count.index).account_name} account"
+  alarm_name                = "AWSConfigChanges-${element(var.accounts, count.index).account_name}"
   comparison_operator       = "GreaterThanOrEqualToThreshold"
   evaluation_periods        = "1"
   metric_name               = aws_cloudwatch_log_metric_filter.aws_config_changes[0].id
@@ -352,7 +352,7 @@ resource "aws_cloudwatch_log_metric_filter" "security_group_changes" {
 resource "aws_cloudwatch_metric_alarm" "security_group_changes" {
   count = var.security_group_changes ? length(var.accounts) : 0
 
-  alarm_name                = "SecurityGroupChanges for ${element(var.accounts, count.index).account_name} account"
+  alarm_name                = "SecurityGroupChanges-${element(var.accounts, count.index).account_name}"
   comparison_operator       = "GreaterThanOrEqualToThreshold"
   evaluation_periods        = "1"
   metric_name               = aws_cloudwatch_log_metric_filter.security_group_changes[0].id
@@ -387,7 +387,7 @@ resource "aws_cloudwatch_log_metric_filter" "nacl_changes" {
 resource "aws_cloudwatch_metric_alarm" "nacl_changes" {
   count = var.nacl_changes ? length(var.accounts) : 0
 
-  alarm_name                = "NACLChanges for ${element(var.accounts, count.index).account_name} account"
+  alarm_name                = "NACLChanges-${element(var.accounts, count.index).account_name}"
   comparison_operator       = "GreaterThanOrEqualToThreshold"
   evaluation_periods        = "1"
   metric_name               = aws_cloudwatch_log_metric_filter.nacl_changes[0].id
@@ -422,7 +422,7 @@ resource "aws_cloudwatch_log_metric_filter" "network_gw_changes" {
 resource "aws_cloudwatch_metric_alarm" "network_gw_changes" {
   count = var.network_gw_changes ? length(var.accounts) : 0
 
-  alarm_name                = "NetworkGWChanges for ${element(var.accounts, count.index).account_name} account"
+  alarm_name                = "NetworkGWChanges-${element(var.accounts, count.index).account_name}"
   comparison_operator       = "GreaterThanOrEqualToThreshold"
   evaluation_periods        = "1"
   metric_name               = aws_cloudwatch_log_metric_filter.network_gw_changes[0].id
@@ -457,7 +457,7 @@ resource "aws_cloudwatch_log_metric_filter" "route_table_changes" {
 resource "aws_cloudwatch_metric_alarm" "route_table_changes" {
   count = var.route_table_changes ? length(var.accounts) : 0
 
-  alarm_name                = "RouteTableChanges for ${element(var.accounts, count.index).account_name} account"
+  alarm_name                = "RouteTableChanges-${element(var.accounts, count.index).account_name}"
   comparison_operator       = "GreaterThanOrEqualToThreshold"
   evaluation_periods        = "1"
   metric_name               = aws_cloudwatch_log_metric_filter.route_table_changes[0].id
@@ -492,7 +492,7 @@ resource "aws_cloudwatch_log_metric_filter" "vpc_changes" {
 resource "aws_cloudwatch_metric_alarm" "vpc_changes" {
   count = var.vpc_changes ? length(var.accounts) : 0
 
-  alarm_name                = "VPCChanges for ${element(var.accounts, count.index).account_name} account"
+  alarm_name                = "VPCChanges-${element(var.accounts, count.index).account_name}"
   comparison_operator       = "GreaterThanOrEqualToThreshold"
   evaluation_periods        = "1"
   metric_name               = aws_cloudwatch_log_metric_filter.vpc_changes[0].id

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 resource "aws_cloudwatch_log_metric_filter" "unauthorized_api_calls" {
-  count = var.unauthorized_api_calls ? length(var.accounts)  : 0
+  count = var.unauthorized_api_calls ? length(var.accounts) : 0
 
   name           = "UnauthorizedAPICalls"
   pattern        = "{ ($.errorCode = \"*UnauthorizedOperation\" && $.userIdentity.accountId = ${element(var.accounts, count.index).account_id}) || ($.errorCode = \"AccessDenied*\" && $.userIdentity.accountId = ${element(var.accounts, count.index).account_id} ) }"
@@ -13,7 +13,7 @@ resource "aws_cloudwatch_log_metric_filter" "unauthorized_api_calls" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "unauthorized_api_calls" {
-  count = var.unauthorized_api_calls ? length(var.accounts)  : 0
+  count = var.unauthorized_api_calls ? length(var.accounts) : 0
 
   alarm_name                = "UnauthorizedAPICalls"
   comparison_operator       = "GreaterThanOrEqualToThreshold"

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 resource "aws_cloudwatch_log_metric_filter" "unauthorized_api_calls" {
   count = var.unauthorized_api_calls ? length(var.accounts) : 0
 
-  name           = "UnauthorizedAPICalls"
+  name           = "UnauthorizedAPICalls: ${element(var.accounts, count.index).account_name}"
   pattern        = "{ ($.errorCode = \"*UnauthorizedOperation\" && $.userIdentity.accountId = ${element(var.accounts, count.index).account_id}) || ($.errorCode = \"AccessDenied*\" && $.userIdentity.accountId = ${element(var.accounts, count.index).account_id}) }"
   log_group_name = var.cloudtrail_log_group_name
 
@@ -15,7 +15,7 @@ resource "aws_cloudwatch_log_metric_filter" "unauthorized_api_calls" {
 resource "aws_cloudwatch_metric_alarm" "unauthorized_api_calls" {
   count = var.unauthorized_api_calls ? length(var.accounts) : 0
 
-  alarm_name                = "UnauthorizedAPICalls"
+  alarm_name                = "UnauthorizedAPICalls: ${element(var.accounts, count.index).account_name}"
   comparison_operator       = "GreaterThanOrEqualToThreshold"
   evaluation_periods        = "1"
   metric_name               = aws_cloudwatch_log_metric_filter.unauthorized_api_calls[0].id
@@ -36,7 +36,7 @@ resource "aws_cloudwatch_metric_alarm" "unauthorized_api_calls" {
 resource "aws_cloudwatch_log_metric_filter" "no_mfa_console_signin_assumed_role" {
   count = var.no_mfa_console_login && ! var.disable_assumed_role_login_alerts ? length(var.accounts) : 0
 
-  name           = "NoMFAConsoleSignin"
+  name           = "NoMFAConsoleSignin: ${element(var.accounts, count.index).account_name}"
   pattern        = "{ ($.eventName = \"ConsoleLogin\") && ($.additionalEventData.MFAUsed != \"Yes\" && $.userIdentity.accountId = ${element(var.accounts, count.index).account_id}) }"
   log_group_name = var.cloudtrail_log_group_name
 
@@ -50,7 +50,7 @@ resource "aws_cloudwatch_log_metric_filter" "no_mfa_console_signin_assumed_role"
 resource "aws_cloudwatch_log_metric_filter" "no_mfa_console_signin_no_assumed_role" {
   count = var.no_mfa_console_login && var.disable_assumed_role_login_alerts ? length(var.accounts) : 0
 
-  name           = "NoMFAConsoleSignin"
+  name           = "NoMFAConsoleSignin: ${element(var.accounts, count.index).account_name}"
   pattern        = "{ ($.eventName = \"ConsoleLogin\") && ($.additionalEventData.MFAUsed != \"Yes\") && ($.userIdentity.arn != \"*assumed-role*\") && ($.userIdentity.accountId = ${element(var.accounts, count.index).account_id}) }"
   log_group_name = var.cloudtrail_log_group_name
 
@@ -64,7 +64,7 @@ resource "aws_cloudwatch_log_metric_filter" "no_mfa_console_signin_no_assumed_ro
 resource "aws_cloudwatch_metric_alarm" "no_mfa_console_signin" {
   count = var.no_mfa_console_login ? length(var.accounts) : 0
 
-  alarm_name                = "NoMFAConsoleSignin"
+  alarm_name                = "NoMFAConsoleSignin: ${element(var.accounts, count.index).account_name}"
   comparison_operator       = "GreaterThanOrEqualToThreshold"
   evaluation_periods        = "1"
   metric_name               = var.disable_assumed_role_login_alerts ? aws_cloudwatch_log_metric_filter.no_mfa_console_signin_no_assumed_role[0].id : aws_cloudwatch_log_metric_filter.no_mfa_console_signin_assumed_role[0].id
@@ -85,7 +85,7 @@ resource "aws_cloudwatch_metric_alarm" "no_mfa_console_signin" {
 resource "aws_cloudwatch_log_metric_filter" "root_usage" {
   count = var.root_usage ? length(var.accounts) : 0
 
-  name           = "RootUsage"
+  name           = "RootUsage: ${element(var.accounts, count.index).account_name}"
   pattern        = "{ $.userIdentity.type = \"Root\" && $.userIdentity.invokedBy NOT EXISTS && $.eventType != \"AwsServiceEvent\" && $.userIdentity.accountId = ${element(var.accounts, count.index).account_id} }"
   log_group_name = var.cloudtrail_log_group_name
 
@@ -99,7 +99,7 @@ resource "aws_cloudwatch_log_metric_filter" "root_usage" {
 resource "aws_cloudwatch_metric_alarm" "root_usage" {
   count = var.root_usage ? length(var.accounts) : 0
 
-  alarm_name                = "RootUsage"
+  alarm_name                = "RootUsage: ${element(var.accounts, count.index).account_name}"
   comparison_operator       = "GreaterThanOrEqualToThreshold"
   evaluation_periods        = "1"
   metric_name               = aws_cloudwatch_log_metric_filter.root_usage[0].id
@@ -120,7 +120,7 @@ resource "aws_cloudwatch_metric_alarm" "root_usage" {
 resource "aws_cloudwatch_log_metric_filter" "iam_changes" {
   count = var.iam_changes ? length(var.accounts) : 0
 
-  name           = "IAMChanges"
+  name           = "IAMChanges: ${element(var.accounts, count.index).account_name}"
   pattern        = "{($.eventName=DeleteGroupPolicy && $.userIdentity.accountId = ${element(var.accounts, count.index).account_id})||($.eventName=DeleteRolePolicy && $.userIdentity.accountId = ${element(var.accounts, count.index).account_id})||($.eventName=DeleteUserPolicy && $.userIdentity.accountId = ${element(var.accounts, count.index).account_id})||($.eventName=PutGroupPolicy && $.userIdentity.accountId = ${element(var.accounts, count.index).account_id})||($.eventName=PutRolePolicy && $.userIdentity.accountId = ${element(var.accounts, count.index).account_id})||($.eventName=PutUserPolicy && $.userIdentity.accountId = ${element(var.accounts, count.index).account_id})||($.eventName=CreatePolicy && $.userIdentity.accountId = ${element(var.accounts, count.index).account_id})||($.eventName=DeletePolicy && $.userIdentity.accountId = ${element(var.accounts, count.index).account_id})||($.eventName=CreatePolicyVersion && $.userIdentity.accountId = ${element(var.accounts, count.index).account_id})||($.eventName=DeletePolicyVersion && $.userIdentity.accountId = ${element(var.accounts, count.index).account_id})||($.eventName=AttachRolePolicy && $.userIdentity.accountId = ${element(var.accounts, count.index).account_id})||($.eventName=DetachRolePolicy && $.userIdentity.accountId = ${element(var.accounts, count.index).account_id})||($.eventName=AttachUserPolicy && $.userIdentity.accountId = ${element(var.accounts, count.index).account_id})||($.eventName=DetachUserPolicy && $.userIdentity.accountId = ${element(var.accounts, count.index).account_id})||($.eventName=AttachGroupPolicy && $.userIdentity.accountId = ${element(var.accounts, count.index).account_id})||($.eventName=DetachGroupPolicy && $.userIdentity.accountId = ${element(var.accounts, count.index).account_id})}"
   log_group_name = var.cloudtrail_log_group_name
 
@@ -134,7 +134,7 @@ resource "aws_cloudwatch_log_metric_filter" "iam_changes" {
 resource "aws_cloudwatch_metric_alarm" "iam_changes" {
   count = var.iam_changes ? length(var.accounts) : 0
 
-  alarm_name                = "IAMChanges"
+  alarm_name                = "IAMChanges: ${element(var.accounts, count.index).account_name}"
   comparison_operator       = "GreaterThanOrEqualToThreshold"
   evaluation_periods        = "1"
   metric_name               = aws_cloudwatch_log_metric_filter.iam_changes[0].id
@@ -155,7 +155,7 @@ resource "aws_cloudwatch_metric_alarm" "iam_changes" {
 resource "aws_cloudwatch_log_metric_filter" "cloudtrail_cfg_changes" {
   count = var.cloudtrail_cfg_changes ? length(var.accounts) : 0
 
-  name           = "CloudTrailCfgChanges"
+  name           = "CloudTrailCfgChanges: ${element(var.accounts, count.index).account_name}"
   pattern        = "{ ($.eventName = CreateTrail && $.userIdentity.accountId = ${element(var.accounts, count.index).account_id}) || ($.eventName = UpdateTrail && $.userIdentity.accountId = ${element(var.accounts, count.index).account_id}) || ($.eventName = DeleteTrail && $.userIdentity.accountId = ${element(var.accounts, count.index).account_id}) || ($.eventName = StartLogging && $.userIdentity.accountId = ${element(var.accounts, count.index).account_id}) || ($.eventName = StopLogging && $.userIdentity.accountId = ${element(var.accounts, count.index).account_id}) }"
   log_group_name = var.cloudtrail_log_group_name
 
@@ -169,7 +169,7 @@ resource "aws_cloudwatch_log_metric_filter" "cloudtrail_cfg_changes" {
 resource "aws_cloudwatch_metric_alarm" "cloudtrail_cfg_changes" {
   count = var.cloudtrail_cfg_changes ? length(var.accounts) : 0
 
-  alarm_name                = "CloudTrailCfgChanges"
+  alarm_name                = "CloudTrailCfgChanges: ${element(var.accounts, count.index).account_name}"
   comparison_operator       = "GreaterThanOrEqualToThreshold"
   evaluation_periods        = "1"
   metric_name               = aws_cloudwatch_log_metric_filter.cloudtrail_cfg_changes[0].id
@@ -190,7 +190,7 @@ resource "aws_cloudwatch_metric_alarm" "cloudtrail_cfg_changes" {
 resource "aws_cloudwatch_log_metric_filter" "console_signin_failures" {
   count = var.console_signin_failures ? length(var.accounts) : 0
 
-  name           = "ConsoleSigninFailures"
+  name           = "ConsoleSigninFailures: ${element(var.accounts, count.index).account_name}"
   pattern        = "{ ($.eventName = ConsoleLogin) && ($.errorMessage = \"Failed authentication\") && ($.userIdentity.accountId = ${element(var.accounts, count.index).account_id}) }"
   log_group_name = var.cloudtrail_log_group_name
 
@@ -204,7 +204,7 @@ resource "aws_cloudwatch_log_metric_filter" "console_signin_failures" {
 resource "aws_cloudwatch_metric_alarm" "console_signin_failures" {
   count = var.console_signin_failures ? length(var.accounts) : 0
 
-  alarm_name                = "ConsoleSigninFailures"
+  alarm_name                = "ConsoleSigninFailures: ${element(var.accounts, count.index).account_name}"
   comparison_operator       = "GreaterThanOrEqualToThreshold"
   evaluation_periods        = "1"
   metric_name               = aws_cloudwatch_log_metric_filter.console_signin_failures[0].id
@@ -225,7 +225,7 @@ resource "aws_cloudwatch_metric_alarm" "console_signin_failures" {
 resource "aws_cloudwatch_log_metric_filter" "disable_or_delete_cmk" {
   count = var.disable_or_delete_cmk ? length(var.accounts) : 0
 
-  name           = "DisableOrDeleteCMK"
+  name           = "DisableOrDeleteCMK: ${element(var.accounts, count.index).account_name}"
   pattern        = "{ ($.eventSource = kms.amazonaws.com) && (($.eventName = DisableKey) || ($.eventName = ScheduleKeyDeletion)) && ($.userIdentity.accountId = ${element(var.accounts, count.index).account_id}) }"
   log_group_name = var.cloudtrail_log_group_name
 
@@ -239,7 +239,7 @@ resource "aws_cloudwatch_log_metric_filter" "disable_or_delete_cmk" {
 resource "aws_cloudwatch_metric_alarm" "disable_or_delete_cmk" {
   count = var.disable_or_delete_cmk ? length(var.accounts) : 0
 
-  alarm_name                = "DisableOrDeleteCMK"
+  alarm_name                = "DisableOrDeleteCMK: ${element(var.accounts, count.index).account_name}"
   comparison_operator       = "GreaterThanOrEqualToThreshold"
   evaluation_periods        = "1"
   metric_name               = aws_cloudwatch_log_metric_filter.disable_or_delete_cmk[0].id
@@ -260,7 +260,7 @@ resource "aws_cloudwatch_metric_alarm" "disable_or_delete_cmk" {
 resource "aws_cloudwatch_log_metric_filter" "s3_bucket_policy_changes" {
   count = var.s3_bucket_policy_changes ? length(var.accounts) : 0
 
-  name           = "S3BucketPolicyChanges"
+  name           = "S3BucketPolicyChanges: ${element(var.accounts, count.index).account_name}"
   pattern        = "{ ($.eventSource = s3.amazonaws.com) && (($.eventName = PutBucketAcl) || ($.eventName = PutBucketPolicy) || ($.eventName = PutBucketCors) || ($.eventName = PutBucketLifecycle) || ($.eventName = PutBucketReplication) || ($.eventName = DeleteBucketPolicy) || ($.eventName = DeleteBucketCors) || ($.eventName = DeleteBucketLifecycle) || ($.eventName = DeleteBucketReplication)) && ($.userIdentity.accountId = ${element(var.accounts, count.index).account_id}) }"
   log_group_name = var.cloudtrail_log_group_name
 
@@ -274,7 +274,7 @@ resource "aws_cloudwatch_log_metric_filter" "s3_bucket_policy_changes" {
 resource "aws_cloudwatch_metric_alarm" "s3_bucket_policy_changes" {
   count = var.s3_bucket_policy_changes ? length(var.accounts) : 0
 
-  alarm_name                = "S3BucketPolicyChanges"
+  alarm_name                = "S3BucketPolicyChanges: ${element(var.accounts, count.index).account_name}"
   comparison_operator       = "GreaterThanOrEqualToThreshold"
   evaluation_periods        = "1"
   metric_name               = aws_cloudwatch_log_metric_filter.s3_bucket_policy_changes[0].id
@@ -295,7 +295,7 @@ resource "aws_cloudwatch_metric_alarm" "s3_bucket_policy_changes" {
 resource "aws_cloudwatch_log_metric_filter" "aws_config_changes" {
   count = var.aws_config_changes ? length(var.accounts) : 0
 
-  name           = "AWSConfigChanges"
+  name           = "AWSConfigChanges: ${element(var.accounts, count.index).account_name}"
   pattern        = "{ ($.eventSource = config.amazonaws.com) && (($.eventName=StopConfigurationRecorder)||($.eventName=DeleteDeliveryChannel)||($.eventName=PutDeliveryChannel)||($.eventName=PutConfigurationRecorder)) && ($.userIdentity.accountId = ${element(var.accounts, count.index).account_id}) }"
   log_group_name = var.cloudtrail_log_group_name
 
@@ -309,7 +309,7 @@ resource "aws_cloudwatch_log_metric_filter" "aws_config_changes" {
 resource "aws_cloudwatch_metric_alarm" "aws_config_changes" {
   count = var.aws_config_changes ? length(var.accounts) : 0
 
-  alarm_name                = "AWSConfigChanges"
+  alarm_name                = "AWSConfigChanges: ${element(var.accounts, count.index).account_name}"
   comparison_operator       = "GreaterThanOrEqualToThreshold"
   evaluation_periods        = "1"
   metric_name               = aws_cloudwatch_log_metric_filter.aws_config_changes[0].id
@@ -330,7 +330,7 @@ resource "aws_cloudwatch_metric_alarm" "aws_config_changes" {
 resource "aws_cloudwatch_log_metric_filter" "security_group_changes" {
   count = var.security_group_changes ? length(var.accounts) : 0
 
-  name           = "SecurityGroupChanges"
+  name           = "SecurityGroupChanges: ${element(var.accounts, count.index).account_name}"
   pattern        = "{ ($.eventName = AuthorizeSecurityGroupIngress && $.userIdentity.accountId = ${element(var.accounts, count.index).account_id}) || ($.eventName = AuthorizeSecurityGroupEgress && $.userIdentity.accountId = ${element(var.accounts, count.index).account_id}) || ($.eventName = RevokeSecurityGroupIngress && $.userIdentity.accountId = ${element(var.accounts, count.index).account_id}) || ($.eventName = RevokeSecurityGroupEgress && $.userIdentity.accountId = ${element(var.accounts, count.index).account_id}) || ($.eventName = CreateSecurityGroup && $.userIdentity.accountId = ${element(var.accounts, count.index).account_id}) || ($.eventName = DeleteSecurityGroup && $.userIdentity.accountId = ${element(var.accounts, count.index).account_id})}"
   log_group_name = var.cloudtrail_log_group_name
 
@@ -344,7 +344,7 @@ resource "aws_cloudwatch_log_metric_filter" "security_group_changes" {
 resource "aws_cloudwatch_metric_alarm" "security_group_changes" {
   count = var.security_group_changes ? length(var.accounts) : 0
 
-  alarm_name                = "SecurityGroupChanges"
+  alarm_name                = "SecurityGroupChanges: ${element(var.accounts, count.index).account_name}"
   comparison_operator       = "GreaterThanOrEqualToThreshold"
   evaluation_periods        = "1"
   metric_name               = aws_cloudwatch_log_metric_filter.security_group_changes[0].id
@@ -365,7 +365,7 @@ resource "aws_cloudwatch_metric_alarm" "security_group_changes" {
 resource "aws_cloudwatch_log_metric_filter" "nacl_changes" {
   count = var.nacl_changes ? length(var.accounts) : 0
 
-  name           = "NACLChanges"
+  name           = "NACLChanges: ${element(var.accounts, count.index).account_name}"
   pattern        = "{ ($.eventName = CreateNetworkAcl && $.userIdentity.accountId = ${element(var.accounts, count.index).account_id}) || ($.eventName = CreateNetworkAclEntry && $.userIdentity.accountId = ${element(var.accounts, count.index).account_id}) || ($.eventName = DeleteNetworkAcl && $.userIdentity.accountId = ${element(var.accounts, count.index).account_id}) || ($.eventName = DeleteNetworkAclEntry && $.userIdentity.accountId = ${element(var.accounts, count.index).account_id}) || ($.eventName = ReplaceNetworkAclEntry && $.userIdentity.accountId = ${element(var.accounts, count.index).account_id}) || ($.eventName = ReplaceNetworkAclAssociation && $.userIdentity.accountId = ${element(var.accounts, count.index).account_id}) }"
   log_group_name = var.cloudtrail_log_group_name
 
@@ -379,7 +379,7 @@ resource "aws_cloudwatch_log_metric_filter" "nacl_changes" {
 resource "aws_cloudwatch_metric_alarm" "nacl_changes" {
   count = var.nacl_changes ? length(var.accounts) : 0
 
-  alarm_name                = "NACLChanges"
+  alarm_name                = "NACLChanges: ${element(var.accounts, count.index).account_name}"
   comparison_operator       = "GreaterThanOrEqualToThreshold"
   evaluation_periods        = "1"
   metric_name               = aws_cloudwatch_log_metric_filter.nacl_changes[0].id
@@ -400,7 +400,7 @@ resource "aws_cloudwatch_metric_alarm" "nacl_changes" {
 resource "aws_cloudwatch_log_metric_filter" "network_gw_changes" {
   count = var.network_gw_changes ? length(var.accounts) : 0
 
-  name           = "NetworkGWChanges"
+  name           = "NetworkGWChanges: ${element(var.accounts, count.index).account_name}"
   pattern        = "{ ($.eventName = CreateCustomerGateway && $.userIdentity.accountId = ${element(var.accounts, count.index).account_id}) || ($.eventName = DeleteCustomerGateway && $.userIdentity.accountId = ${element(var.accounts, count.index).account_id}) || ($.eventName = AttachInternetGateway && $.userIdentity.accountId = ${element(var.accounts, count.index).account_id}) || ($.eventName = CreateInternetGateway && $.userIdentity.accountId = ${element(var.accounts, count.index).account_id}) || ($.eventName = DeleteInternetGateway && $.userIdentity.accountId = ${element(var.accounts, count.index).account_id}) || ($.eventName = DetachInternetGateway && $.userIdentity.accountId = ${element(var.accounts, count.index).account_id}) }"
   log_group_name = var.cloudtrail_log_group_name
 
@@ -414,7 +414,7 @@ resource "aws_cloudwatch_log_metric_filter" "network_gw_changes" {
 resource "aws_cloudwatch_metric_alarm" "network_gw_changes" {
   count = var.network_gw_changes ? length(var.accounts) : 0
 
-  alarm_name                = "NetworkGWChanges"
+  alarm_name                = "NetworkGWChanges: ${element(var.accounts, count.index).account_name}"
   comparison_operator       = "GreaterThanOrEqualToThreshold"
   evaluation_periods        = "1"
   metric_name               = aws_cloudwatch_log_metric_filter.network_gw_changes[0].id
@@ -435,7 +435,7 @@ resource "aws_cloudwatch_metric_alarm" "network_gw_changes" {
 resource "aws_cloudwatch_log_metric_filter" "route_table_changes" {
   count = var.route_table_changes ? length(var.accounts) : 0
 
-  name           = "RouteTableChanges"
+  name           = "RouteTableChanges: ${element(var.accounts, count.index).account_name}"
   pattern        = "{ ($.eventName = CreateRoute && $.userIdentity.accountId = ${element(var.accounts, count.index).account_id}) || ($.eventName = CreateRouteTable && $.userIdentity.accountId = ${element(var.accounts, count.index).account_id}) || ($.eventName = ReplaceRoute && $.userIdentity.accountId = ${element(var.accounts, count.index).account_id}) || ($.eventName = ReplaceRouteTableAssociation && $.userIdentity.accountId = ${element(var.accounts, count.index).account_id}) || ($.eventName = DeleteRouteTable && $.userIdentity.accountId = ${element(var.accounts, count.index).account_id}) || ($.eventName = DeleteRoute && $.userIdentity.accountId = ${element(var.accounts, count.index).account_id}) || ($.eventName = DisassociateRouteTable && $.userIdentity.accountId = ${element(var.accounts, count.index).account_id}) }"
   log_group_name = var.cloudtrail_log_group_name
 
@@ -449,7 +449,7 @@ resource "aws_cloudwatch_log_metric_filter" "route_table_changes" {
 resource "aws_cloudwatch_metric_alarm" "route_table_changes" {
   count = var.route_table_changes ? length(var.accounts) : 0
 
-  alarm_name                = "RouteTableChanges"
+  alarm_name                = "RouteTableChanges: ${element(var.accounts, count.index).account_name}"
   comparison_operator       = "GreaterThanOrEqualToThreshold"
   evaluation_periods        = "1"
   metric_name               = aws_cloudwatch_log_metric_filter.route_table_changes[0].id
@@ -470,7 +470,7 @@ resource "aws_cloudwatch_metric_alarm" "route_table_changes" {
 resource "aws_cloudwatch_log_metric_filter" "vpc_changes" {
   count = var.vpc_changes ? length(var.accounts) : 0
 
-  name           = "VPCChanges"
+  name           = "VPCChanges: ${element(var.accounts, count.index).account_name}"
   pattern        = "{ ($.eventName = CreateVpc && $.userIdentity.accountId = ${element(var.accounts, count.index).account_id}) || ($.eventName = DeleteVpc && $.userIdentity.accountId = ${element(var.accounts, count.index).account_id}) || ($.eventName = ModifyVpcAttribute && $.userIdentity.accountId = ${element(var.accounts, count.index).account_id}) || ($.eventName = AcceptVpcPeeringConnection && $.userIdentity.accountId = ${element(var.accounts, count.index).account_id}) || ($.eventName = CreateVpcPeeringConnection && $.userIdentity.accountId = ${element(var.accounts, count.index).account_id}) || ($.eventName = DeleteVpcPeeringConnection && $.userIdentity.accountId = ${element(var.accounts, count.index).account_id}) || ($.eventName = RejectVpcPeeringConnection && $.userIdentity.accountId = ${element(var.accounts, count.index).account_id}) || ($.eventName = AttachClassicLinkVpc && $.userIdentity.accountId = ${element(var.accounts, count.index).account_id}) || ($.eventName = DetachClassicLinkVpc && $.userIdentity.accountId = ${element(var.accounts, count.index).account_id}) || ($.eventName = DisableVpcClassicLink && $.userIdentity.accountId = ${element(var.accounts, count.index).account_id}) || ($.eventName = EnableVpcClassicLink && $.userIdentity.accountId = ${element(var.accounts, count.index).account_id}) }"
   log_group_name = var.cloudtrail_log_group_name
 
@@ -484,7 +484,7 @@ resource "aws_cloudwatch_log_metric_filter" "vpc_changes" {
 resource "aws_cloudwatch_metric_alarm" "vpc_changes" {
   count = var.vpc_changes ? length(var.accounts) : 0
 
-  alarm_name                = "VPCChanges"
+  alarm_name                = "VPCChanges: ${element(var.accounts, count.index).account_name}"
   comparison_operator       = "GreaterThanOrEqualToThreshold"
   evaluation_periods        = "1"
   metric_name               = aws_cloudwatch_log_metric_filter.vpc_changes[0].id

--- a/variables.tf
+++ b/variables.tf
@@ -4,7 +4,7 @@ variable "accounts" {
   description = "To split alert by account, add account IDs of interest"
   type = list(
     object({
-      account_id = string
+      account_id   = string
       account_name = string
       }
     )

--- a/variables.tf
+++ b/variables.tf
@@ -1,7 +1,7 @@
 # Setup Variables
 
 variable "accounts" {
-  description = "To split alert by account, add account IDs of interest"
+  description = "List of account objects containing the account_id and account_name to alert on."
   type = list(
     object({
       account_id   = string

--- a/variables.tf
+++ b/variables.tf
@@ -1,5 +1,16 @@
 # Setup Variables
 
+variable "accounts" {
+  description = "To split alert by account, add account IDs of interest"
+  type = list(
+    object({
+      account_id = string
+      account_name = string
+      }
+    )
+  )
+}
+
 variable "alarm_namespace" {
   description = "Namespace for generated Cloudwatch alarms"
   type        = string


### PR DESCRIPTION
Currently this module supports one instance of the module per account. If, however, you create an instance of this module in an AWS org with multiple accounts, it's impossible to track which account the alert is coming from. Below is an example of a plan for running this with multiple accounts on `aws_cloudwatch_log_metric` for `unauthorized_api_calls`. 

```shell
Terraform will perform the following actions:

  # module.cloudtrail_alarms.aws_cloudwatch_metric_alarm.unauthorized_api_calls[0] must be replaced
-/+ resource "aws_cloudwatch_metric_alarm" "unauthorized_api_calls" {
        actions_enabled                       = true
        alarm_actions                         = [
            "arn:aws:sns:us-west-2:937541588026:saber-slack-alerts",
        ]
      ~ alarm_description                     = "Monitoring unauthorized API calls will help reveal application errors and may reduce time to detect malicious activity." -> "Alert for account usdod-saber-org-root (ID: 937541588026). Alert for account usdod-saber-org-root (ID: 937541588026). Monitoring unauthorized API calls will help reveal application errors and may reduce time to detect malicious activity."
      ~ alarm_name                            = "UnauthorizedAPICalls" -> "UnauthorizedAPICalls for usdod-saber-org-root account" # forces replacement
      ~ arn                                   = "arn:aws:cloudwatch:us-west-2:937541588026:alarm:UnauthorizedAPICalls" -> (known after apply)
        comparison_operator                   = "GreaterThanOrEqualToThreshold"
      - datapoints_to_alarm                   = 0 -> null
      - dimensions                            = {} -> null
      + evaluate_low_sample_count_percentiles = (known after apply)
        evaluation_periods                    = 1
      ~ id                                    = "UnauthorizedAPICalls" -> (known after apply)
      - insufficient_data_actions             = [] -> null
      ~ metric_name                           = "UnauthorizedAPICalls" -> (known after apply)
        namespace                             = "CISBenchmark"
      - ok_actions                            = [] -> null
        period                                = 300
        statistic                             = "Sum"
        tags                                  = {
            "Automation" = "Terraform"
        }
        threshold                             = 1
        treat_missing_data                    = "notBreaching"
    }

  # module.cloudtrail_alarms.aws_cloudwatch_metric_alarm.unauthorized_api_calls[1] will be created
  + resource "aws_cloudwatch_metric_alarm" "unauthorized_api_calls" {
      + actions_enabled                       = true
      + alarm_actions                         = [
          + "arn:aws:sns:us-west-2:937541588026:saber-slack-alerts",
        ]
      + alarm_description                     = "Alert for account usdod-saber-id (ID: 138713145137). Alert for account usdod-saber-id (ID: 138713145137). Monitoring unauthorized API calls will help reveal application errors and may reduce time to detect malicious activity."
      + alarm_name                            = "UnauthorizedAPICalls for usdod-saber-id account"
      + arn                                   = (known after apply)
      + comparison_operator                   = "GreaterThanOrEqualToThreshold"
      + evaluate_low_sample_count_percentiles = (known after apply)
      + evaluation_periods                    = 1
      + id                                    = (known after apply)
      + metric_name                           = (known after apply)
      + namespace                             = "CISBenchmark"
      + period                                = 300
      + statistic                             = "Sum"
      + tags                                  = {
          + "Automation" = "Terraform"
        }
      + threshold                             = 1
      + treat_missing_data                    = "notBreaching"
    }

  # module.cloudtrail_alarms.aws_cloudwatch_metric_alarm.unauthorized_api_calls[2] will be created
  + resource "aws_cloudwatch_metric_alarm" "unauthorized_api_calls" {
      + actions_enabled                       = true
      + alarm_actions                         = [
          + "arn:aws:sns:us-west-2:937541588026:saber-slack-alerts",
        ]
      + alarm_description                     = "Alert for account usdod-saber-sandbox (ID: 087088297596). Alert for account usdod-saber-sandbox (ID: 087088297596). Monitoring unauthorized API calls will help reveal application errors and may reduce time to detect malicious activity."
      + alarm_name                            = "UnauthorizedAPICalls for usdod-saber-sandbox account"
      + arn                                   = (known after apply)
      + comparison_operator                   = "GreaterThanOrEqualToThreshold"
      + evaluate_low_sample_count_percentiles = (known after apply)
      + evaluation_periods                    = 1
      + id                                    = (known after apply)
      + metric_name                           = (known after apply)
      + namespace                             = "CISBenchmark"
      + period                                = 300
      + statistic                             = "Sum"
      + tags                                  = {
          + "Automation" = "Terraform"
        }
      + threshold                             = 1
      + treat_missing_data                    = "notBreaching"
    }

  # module.cloudtrail_alarms.aws_cloudwatch_metric_alarm.unauthorized_api_calls[3] will be created
  + resource "aws_cloudwatch_metric_alarm" "unauthorized_api_calls" {
      + actions_enabled                       = true
      + alarm_actions                         = [
          + "arn:aws:sns:us-west-2:937541588026:saber-slack-alerts",
        ]
      + alarm_description                     = "Alert for account usdod-saber-infra (ID: 583951903209). Alert for account usdod-saber-infra (ID: 583951903209). Monitoring unauthorized API calls will help reveal application errors and may reduce time to detect malicious activity."
      + alarm_name                            = "UnauthorizedAPICalls for usdod-saber-infra account"
      + arn                                   = (known after apply)
      + comparison_operator                   = "GreaterThanOrEqualToThreshold"
      + evaluate_low_sample_count_percentiles = (known after apply)
      + evaluation_periods                    = 1
      + id                                    = (known after apply)
      + metric_name                           = (known after apply)
      + namespace                             = "CISBenchmark"
      + period                                = 300
      + statistic                             = "Sum"
      + tags                                  = {
          + "Automation" = "Terraform"
        }
      + threshold                             = 1
      + treat_missing_data                    = "notBreaching"
    }

  # module.cloudtrail_alarms.aws_cloudwatch_metric_alarm.unauthorized_api_calls[4] will be created
  + resource "aws_cloudwatch_metric_alarm" "unauthorized_api_calls" {
      + actions_enabled                       = true
      + alarm_actions                         = [
          + "arn:aws:sns:us-west-2:937541588026:saber-slack-alerts",
        ]
      + alarm_description                     = "Alert for account usdod-saber-staging (ID: 360531269602). Alert for account usdod-saber-staging (ID: 360531269602). Monitoring unauthorized API calls will help reveal application errors and may reduce time to detect malicious activity."
      + alarm_name                            = "UnauthorizedAPICalls for usdod-saber-staging account"
      + arn                                   = (known after apply)
      + comparison_operator                   = "GreaterThanOrEqualToThreshold"
      + evaluate_low_sample_count_percentiles = (known after apply)
      + evaluation_periods                    = 1
      + id                                    = (known after apply)
      + metric_name                           = (known after apply)
      + namespace                             = "CISBenchmark"
      + period                                = 300
      + statistic                             = "Sum"
      + tags                                  = {
          + "Automation" = "Terraform"
        }
      + threshold                             = 1
      + treat_missing_data                    = "notBreaching"
    }
```

### Notes

Testing this is going to be tricky because we do actually need to trigger rather than just verify they were set up correctly. Going to follow up in Slack to figure out a testing plan.
