### PR TITLE
Keep allowing same old versions

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -1,7 +1,7 @@
 terraform {
-  required_version = "~> 0.13.0"
+  required_version = ">= 0.12.0"
 
   required_providers {
-    aws = "~> 3.0"
+    aws = ">= 2.70"
   }
 }


### PR DESCRIPTION
The states created with tag 1.1.1 uses terraform 0.12 but since tag 2.0.0. requires provider tf 0.13 states can not be used with the tag (or any future newer)
Probably same/similar with provider.

So unless there are some non backwards compatible changes for cloudtrail alarms in higher versions I think it is nice to allow both in module to give time for users to migrate to newer versions in their setups.