### PR TITLE
Update alarm description for disable_or_delete_cmk

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
     - auth:
         password: $DOCKER_PASSWORD
         username: $DOCKER_USERNAME
-      image: trussworks/circleci:efb1042e31538677779971798e0912390f699e72
+      image: trussworks/circleci:62e7cada934784e47333e47175be728aa3475b02
     steps:
     - checkout
     - restore_cache:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,12 +12,12 @@ repos:
       - id: trailing-whitespace
 
   - repo: git://github.com/igorshubovych/markdownlint-cli
-    rev: v0.26.0
+    rev: v0.27.1
     hooks:
       - id: markdownlint
 
   - repo: git://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.45.0
+    rev: v1.48.0
     hooks:
       - id: terraform_docs
       - id: terraform_fmt

--- a/README.md
+++ b/README.md
@@ -59,6 +59,17 @@ Terraform 0.12. Pin module version to `~> 1.X`. Submit pull-requests to `terrafo
 |------|---------|
 | aws | >= 3.0 |
 
+## Modules
+
+No Modules.
+
+## Resources
+
+| Name |
+|------|
+| [aws_cloudwatch_log_metric_filter](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_metric_filter) |
+| [aws_cloudwatch_metric_alarm](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -85,5 +96,4 @@ Terraform 0.12. Pin module version to `~> 1.X`. Submit pull-requests to `terrafo
 ## Outputs
 
 No output.
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/main.tf
+++ b/main.tf
@@ -34,7 +34,7 @@ resource "aws_cloudwatch_metric_alarm" "unauthorized_api_calls" {
 }
 
 resource "aws_cloudwatch_log_metric_filter" "no_mfa_console_signin_assumed_role" {
-  count = var.no_mfa_console_login && ! var.disable_assumed_role_login_alerts ? 1 : 0
+  count = var.no_mfa_console_login && !var.disable_assumed_role_login_alerts ? 1 : 0
 
   name           = "NoMFAConsoleSignin"
   pattern        = "{ ($.eventName = \"ConsoleLogin\") && ($.additionalEventData.MFAUsed != \"Yes\") }"

--- a/main.tf
+++ b/main.tf
@@ -34,7 +34,7 @@ resource "aws_cloudwatch_metric_alarm" "unauthorized_api_calls" {
 }
 
 resource "aws_cloudwatch_log_metric_filter" "no_mfa_console_signin_assumed_role" {
-  count = var.no_mfa_console_login && !var.disable_assumed_role_login_alerts ? 1 : 0
+  count = var.no_mfa_console_login && ! var.disable_assumed_role_login_alerts ? 1 : 0
 
   name           = "NoMFAConsoleSignin"
   pattern        = "{ ($.eventName = \"ConsoleLogin\") && ($.additionalEventData.MFAUsed != \"Yes\") }"
@@ -247,7 +247,7 @@ resource "aws_cloudwatch_metric_alarm" "disable_or_delete_cmk" {
   period                    = "300"
   statistic                 = "Sum"
   threshold                 = "1"
-  alarm_description         = "Monitoring failed console logins may decrease lead time to detect an attempt to brute force a credential, which may provide an indicator, such as source IP, that can be used in other event correlation."
+  alarm_description         = "Data encrypted with disabled or deleted keys will no longer be accessible."
   alarm_actions             = [var.alarm_sns_topic_arn]
   treat_missing_data        = "notBreaching"
   insufficient_data_actions = []


### PR DESCRIPTION
The current alarm description for DisableOrDeleteCMK uses the same text as the ConsoleSigninFailures alarm, which I imagine was inadvertent.

This PR updates the DisableOrDeleteCMK alarm descriptions and makes minor pre-commit and CircleCI image updates, particularly around the terraform-docs formatting.