### PR TITLE
deprecate older terraform versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,12 +34,6 @@ repos:
     hooks:
       - id: shell-lint
 
-  - repo: https://github.com/terraform-docs/terraform-docs
-    rev: "v0.16.0"
-    hooks:
-      - id: terraform-docs-go
-        args: ["markdown", "table", "--output-file", "README.md", "."]
-
   - repo: https://github.com/antonbabenko/pre-commit-terraform
     rev: v1.77.1
     hooks:

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ module "cloudtrail_alarms" {
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.13.0 |
+| terraform | >= 1.0 |
 | aws | >= 3.0 |
 
 ## Providers

--- a/README.md
+++ b/README.md
@@ -39,12 +39,6 @@ module "cloudtrail_alarms" {
 }
 ```
 
-## Terraform Versions
-
-Terraform 0.13. Pin module version to `~> 2.X`. Submit pull-requests to `master` branch.
-
-Terraform 0.12. Pin module version to `~> 1.X`. Submit pull-requests to `terraform012` branch.
-
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13.0"
+  required_version = ">= 1.0"
 
   required_providers {
     aws = ">= 3.0"


### PR DESCRIPTION
-   Modified README
-   Set expected terraform version to be equal or greater than Terraform version 1.0
